### PR TITLE
Patch 1.0.x to remain compatible with solidus 1.3

### DIFF
--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -1,6 +1,16 @@
 module Spree
   module Stock
     module EstimatorDecorator
+      # Added here to provide compatibility moving forward with solidus, which
+      # as of v1.3.0 changed the Estimator initialization signature to no longer
+      # accept arguments.
+      #
+      # This is added here to allow a version of the easypost gem to be
+      # compatible with both pre and post v1.3 versions and initialize
+      # an Estimator in the specs
+      def initialize(order=nil)
+      end
+
       def shipping_rates(package)
         shipment = package.easypost_shipment
         rates = shipment.rates.sort_by { |r| r.rate.to_i }

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -16,7 +16,7 @@ module Spree
         rates = shipment.rates.sort_by { |r| r.rate.to_i }
 
         if rates.any?
-          rates.each do |rate|
+          spree_rates = rates.map do |rate|
             spree_rate = Spree::ShippingRate.new(
               name: "#{ rate.carrier } #{ rate.service }",
               cost: rate.rate,
@@ -25,15 +25,15 @@ module Spree
               shipping_method: find_or_create_shipping_method(rate)
             )
 
-            package.shipping_rates << spree_rate if spree_rate.shipping_method.frontend?
-          end
+            spree_rate if spree_rate.shipping_method.frontend?
+          end.compact
 
           # Sets cheapest rate to be selected by default
-          if package.shipping_rates.any?
-            package.shipping_rates.min_by(&:cost).selected = true
+          if spree_rates.any?
+            spree_rates.min_by(&:cost).selected = true
           end
 
-          package.shipping_rates
+          spree_rates
         else
           []
         end


### PR DESCRIPTION
In solidusio/solidus@796ed7fa49e793360a1b47b6df03a7bc2a116ccf and solidusio/solidus@0684205c22d91835f4ba0e87efe6d0fb3b20c5fa. Two changes were made which limited the compatibility of this gem.

The first was the change of the `Spree::Stock::Estimator` to no longer accept initialization arguments. While this didn't affect the behaviour of this gem, the specs do initialize a `Spree::Stock::Estimator` to test the `#shipping_rates` method in isolation. 

This PR overrides the default Estimator initialization method to make the order argument optional. Even if it is not used. This way v1.0.3 will be compatible with versions which came both before and after this change in soludus.

The second change was the removal of shipping rates from `Spree::Stock::Package`. This had a more direct impact on the gem since the current implementation of the Stock::Estimator set the shipping rates on the packages directly. 

However as seen [here](https://github.com/solidusio/solidus/commit/796ed7fa49e793360a1b47b6df03a7bc2a116ccf#diff-6289a1a8d0052dc24e66d7b72ca93869L124) This was more the responsibility of the stock coordinator to begin with and `#shipping_rates` is just expected to return an array of `Spree::ShippingRate`.

To remain compatible, The solidus_easypost version now no longer sets the shipping rates on packages directly, and instead simply returns them to the coordiator to be set on shipments there.

There are are a few more behaviour differences in what the Solidus default Estimator does versus the current solidus easy post gem estimator, but these will be addressed in future versions of the gem. This PR is the bare minimum needed to stay compatible with Solidus v1.3
