### PR TITLE
Add some configuration and helpful info to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This goes into a new file called `config/initializers/easy_post.rb`:
   EasyPost.api_key = 'YOUR_API_KEY_HERE'
 ```
 
-
 ## Usage
 
 This extension hijacks `Spree::Stock::Estimator#shipping_rates` to calculate shipping rates for your orders. This call happens during the checkout process, once the order's address information has been provided.
@@ -36,6 +35,20 @@ The extension also adds a callback to the "ship" event on the `Shipment` model, 
 
 This gem will create shipping methods for each type of carrier/service for which it receives a rate from the EasyPost API. These are set to  `display_on: back_end` by default and must be set to `front_end`
 or `both` before the rate will be visible on the delivery page of the checkout.
+
+## Getting Started
+
+Some easy mistakes to run into when initially setting up this gem are:
+- EasyPost Requires that Packages have a weight. Ensure that Variants have a non
+  zero weight value.
+- EasyPost performs address validation on addresses. Ensure the ship_address and
+  bill_address are valid addresses.
+- This Gem currently looks for Shipping Methods which have admin names which
+  match the pattern `<Carrier Name> <Service Level>`. If it cant find an
+  existing match, a new shipping method is created with `display_on=:backend`.
+  The first order placed may receive a message of no "shipping rates found".
+  Check if new Shipping Methods were created in the admin `Settings>Shipping`
+  section, and ensure at lease one shipping method is `display_on=<:both or :frond_end>`
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,29 @@ or `both` before the rate will be visible on the delivery page of the checkout.
 ## Getting Started
 
 Some easy mistakes to run into when initially setting up this gem are:
-- EasyPost Requires that Packages have a weight. Ensure that Variants have a non
+- EasyPost requires that packages have a weight. Ensure that variants have a non
   zero weight value.
-- EasyPost performs address validation on addresses. Ensure the ship_address and
-  bill_address are valid addresses.
-- This Gem currently looks for Shipping Methods which have admin names which
+- EasyPost performs address validation on addresses. Ensure the order
+  ship_address and stock location address are valid addresses.
+- This Gem currently looks for shipping methods which have admin names which
   match the pattern `<Carrier Name> <Service Level>`. If it cant find an
   existing match, a new shipping method is created with `display_on=:backend`.
   The first order placed may receive a message of no "shipping rates found".
   Check if new Shipping Methods were created in the admin `Settings>Shipping`
-  section, and ensure at lease one shipping method is `display_on=<:both or :frond_end>`
+  section, and ensure at least one shipping method is `display_on=<:both or :frond_end>`
+
+## Compatibility
+
+Although the goal is for every version of this gem to be compatible with every
+version of Solidus. It is possible for Solidus to introduce breaking changes
+which make older versions of this gem incompatible with newer versions of Solidus.
+We will make sure to patch old versions to remain compatible with supported
+versions of Solidus.
+
+|solidues_easypost version|Compatible up to solidus version|
+|---|---|
+|v1.0.2|< v1.3.0|
+|v1.0.3|master|
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This goes in your terminal:
 
 This goes into a new file called `config/initializers/easy_post.rb`:
 ```ruby
+  require 'spree_easypost'
   EasyPost.api_key = 'YOUR_API_KEY_HERE'
 ```
 


### PR DESCRIPTION
There are a few quirks in setting up this gem and I think it is a better experience for them to be presented upfront so users don't need to hunt them down.

The first is that in the migration from spree -> solidus the lib/spree_easypost file wasn't renamed to solidus_easypost. And so bundler cant automagically require it. The solution for this in the 1.0.x versions will be to explicitly require the correct gem in the initializer which is required anyway.
The next minor version will actually correct this issue by renaming the file. 

Next is there are few setup mistakes which are easy to make and easy to avoid so having them upfront should help users avoid making them.

The last addition is the addition of a compatibility table. Solidus 1.3.0 broke the compatibility for v1.0.2 of this gem. And while v1.0.3 will fix the compatibility issue. Its good to say upfront that v1.0.2 is only compatible up to solidus 1.0.3 and then an update is required.  
