### PR TITLE
Add Compatibility table to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ The extension also adds a callback to the "ship" event on the `Shipment` model, 
 This gem will create shipping methods for each type of carrier/service for which it receives a rate from the EasyPost API. These are set to  `display_on: back_end` by default and must be set to `front_end`
 or `both` before the rate will be visible on the delivery page of the checkout.
 
+## Getting Started
+
+Some easy mistakes to run into when initially setting up this gem are:
+- EasyPost requires that packages have a weight. Ensure that variants have a non
+  zero weight value.
+- EasyPost performs address validation on addresses. Ensure the order
+  ship_address and stock location address are valid addresses.
+- This Gem currently looks for shipping methods which have admin names which
+  match the pattern `<Carrier Name> <Service Level>`. If it cant find an
+  existing match, a new shipping method is created with `display_on=:backend`.
+  The first order placed may receive a message of no "shipping rates found".
+  Check if new Shipping Methods were created in the admin `Settings>Shipping`
+  section, and ensure at least one shipping method is `display_on=<:both or :frond_end>`
+
+## Compatibility
+
+Although the goal is for every version of this gem to be compatible with every
+version of Solidus. It is possible for Solidus to introduce breaking changes
+which make older versions of this gem incompatible with newer versions of Solidus.
+We will make sure to patch old versions to remain compatible with supported
+versions of Solidus.
+
+|solidues_easypost version|Compatible up to solidus version|
+|---|---|
+|v1.0.2|< v1.3.0|
+|v1.0.3|master|
+
 ## Issues
 
 Please let me know if you find any issues in [the usual places](https://github.com/solidusio-contrib/solidus_easypost/issues), with [the usual information](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Solidus 1.3 introduced breaking changes to the solidus_easypost gem by
changing the method signature of the Estimator initilizer and by
removing Package#shipping_rates.

This changes have been accomodated for v1.0.3 of this gem, but I want to
add an explicit chart to indicate that v1.0.3 is only compatible upto
solidus version less than v1.3.0.
