### PR TITLE
Fix Gem loading

### DIFF
--- a/lib/solidus_easypost.rb
+++ b/lib/solidus_easypost.rb
@@ -1,0 +1,1 @@
+require 'spree_easypost'


### PR DESCRIPTION
The name of the gem changed, but the name of the initializing file in
the gem was not updated.

This adds a new file which requires the old file. This will not break
any workarounds anyone put in place to work around the problem
