### PR TITLE
Support Solidus 1.3 and beyond

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,22 @@ rvm:
   - '2.3.0'
 env:
   matrix:
+    - SOLIDUS_BRANCH=master DB=postgres
+    - SOLIDUS_BRANCH=v2.2   DB=postgres
+    - SOLIDUS_BRANCH=v2.1   DB=postgres
+    - SOLIDUS_BRANCH=v2.0   DB=postgres
+    - SOLIDUS_BRANCH=v1.4   DB=postgres
+    - SOLIDUS_BRANCH=v1.3   DB=postgres
     - SOLIDUS_BRANCH=v1.2   DB=postgres
     - SOLIDUS_BRANCH=v1.1   DB=postgres
-    - SOLIDUS_BRANCH=v1.0   DB=postgres
+    - SOLIDUS_BRANCH=master DB=mysql
+    - SOLIDUS_BRANCH=v2.2   DB=mysql
+    - SOLIDUS_BRANCH=v2.1   DB=mysql
+    - SOLIDUS_BRANCH=v2.0   DB=mysql
+    - SOLIDUS_BRANCH=v1.4   DB=mysql
+    - SOLIDUS_BRANCH=v1.3   DB=mysql
     - SOLIDUS_BRANCH=v1.2   DB=mysql
     - SOLIDUS_BRANCH=v1.1   DB=mysql
-    - SOLIDUS_BRANCH=v1.0   DB=mysql
 sudo: false
 before_script:
   - bundle exec rake test_app

--- a/app/models/solidus_easypost/estimator.rb
+++ b/app/models/solidus_easypost/estimator.rb
@@ -1,0 +1,49 @@
+module SolidusEasypost
+  class Estimator
+    def shipping_rates(package, frontend_only = true)
+      shipment = package.easypost_shipment
+      rates = shipment.rates.sort_by { |r| r.rate.to_i }
+
+      shipping_rates = []
+
+      if rates.any?
+        rates.each do |rate|
+          spree_rate = Spree::ShippingRate.new(
+            name: "#{ rate.carrier } #{ rate.service }",
+            cost: rate.rate,
+            easy_post_shipment_id: rate.shipment_id,
+            easy_post_rate_id: rate.id,
+            shipping_method: find_or_create_shipping_method(rate)
+          )
+
+          shipping_rates << spree_rate if spree_rate.shipping_method.frontend?
+        end
+
+        # Sets cheapest rate to be selected by default
+        if shipping_rates.any?
+          shipping_rates.min_by(&:cost).selected = true
+        end
+
+        shipping_rates
+      else
+        []
+      end
+    end
+
+    private
+
+    # Cartons require shipping methods to be present, This will lookup a
+    # Shipping method based on the admin(internal)_name. This is not user facing
+    # and should not be changed in the admin.
+    def find_or_create_shipping_method(rate)
+      method_name = "#{ rate.carrier } #{ rate.service }"
+      Spree::ShippingMethod.find_or_create_by(admin_name: method_name) do |r|
+        r.name = method_name
+        r.display_on = :back_end
+        r.code = rate.service
+        r.calculator = Spree::Calculator::Shipping::FlatRate.create
+        r.shipping_categories = [Spree::ShippingCategory.first]
+      end
+    end
+  end
+end

--- a/app/models/solidus_easypost/estimator.rb
+++ b/app/models/solidus_easypost/estimator.rb
@@ -39,7 +39,7 @@ module SolidusEasypost
       method_name = "#{ rate.carrier } #{ rate.service }"
       Spree::ShippingMethod.find_or_create_by(admin_name: method_name) do |r|
         r.name = method_name
-        r.display_on = :back_end
+        r.display_on = 'back_end'
         r.code = rate.service
         r.calculator = Spree::Calculator::Shipping::FlatRate.create
         r.shipping_categories = [Spree::ShippingCategory.first]

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -10,7 +10,7 @@ module Spree
           phone: phone
         }
 
-        attributes[:company] = respond_to?(:company)? company : Spree::Store.current.name
+        attributes[:company] = company if respond_to?(:company)
         attributes[:name] = full_name if respond_to?(:full_name)
         attributes[:state] = state ? state.abbr : state_name
         attributes[:country] = country.try(:iso)

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -28,7 +28,7 @@ module Spree
 
     def build_easypost_shipment
       ::EasyPost::Shipment.create(
-        to_address: address.easypost_address,
+        to_address: order.ship_address.easypost_address,
         from_address: stock_location.easypost_address,
         parcel: to_package.easypost_parcel
       )

--- a/app/models/spree/shipping_rate_decorator.rb
+++ b/app/models/spree/shipping_rate_decorator.rb
@@ -1,7 +1,7 @@
 module Spree
   module ShippingRateDecorator
     def name
-      read_attribute(:name)
+      read_attribute(:name) || super
     end
   end
 end

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -1,9 +1,11 @@
 module Spree
   module Stock
     module EstimatorDecorator
-      def shipping_rates(package)
+      def shipping_rates(package, frontend_only = true)
         shipment = package.easypost_shipment
         rates = shipment.rates.sort_by { |r| r.rate.to_i }
+
+        shipping_rates = []
 
         if rates.any?
           rates.each do |rate|
@@ -15,15 +17,15 @@ module Spree
               shipping_method: find_or_create_shipping_method(rate)
             )
 
-            package.shipping_rates << spree_rate if spree_rate.shipping_method.frontend?
+            shipping_rates << spree_rate if spree_rate.shipping_method.frontend?
           end
 
           # Sets cheapest rate to be selected by default
-          if package.shipping_rates.any?
-            package.shipping_rates.min_by(&:cost).selected = true
+          if shipping_rates.any?
+            shipping_rates.min_by(&:cost).selected = true
           end
 
-          package.shipping_rates
+          shipping_rates
         else
           []
         end

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -2,49 +2,7 @@ module Spree
   module Stock
     module EstimatorDecorator
       def shipping_rates(package, frontend_only = true)
-        shipment = package.easypost_shipment
-        rates = shipment.rates.sort_by { |r| r.rate.to_i }
-
-        shipping_rates = []
-
-        if rates.any?
-          rates.each do |rate|
-            spree_rate = Spree::ShippingRate.new(
-              name: "#{ rate.carrier } #{ rate.service }",
-              cost: rate.rate,
-              easy_post_shipment_id: rate.shipment_id,
-              easy_post_rate_id: rate.id,
-              shipping_method: find_or_create_shipping_method(rate)
-            )
-
-            shipping_rates << spree_rate if spree_rate.shipping_method.frontend?
-          end
-
-          # Sets cheapest rate to be selected by default
-          if shipping_rates.any?
-            shipping_rates.min_by(&:cost).selected = true
-          end
-
-          shipping_rates
-        else
-          []
-        end
-      end
-
-      private
-
-      # Cartons require shipping methods to be present, This will lookup a
-      # Shipping method based on the admin(internal)_name. This is not user facing
-      # and should not be changed in the admin.
-      def find_or_create_shipping_method(rate)
-        method_name = "#{ rate.carrier } #{ rate.service }"
-        Spree::ShippingMethod.find_or_create_by(admin_name: method_name) do |r|
-          r.name = method_name
-          r.display_on = :back_end
-          r.code = rate.service
-          r.calculator = Spree::Calculator::Shipping::FlatRate.create
-          r.shipping_categories = [Spree::ShippingCategory.first]
-        end
+        SolidusEasypost::Estimator.new.shipping_rates(package, frontend_only)
       end
     end
   end

--- a/lib/spree_easypost.rb
+++ b/lib/spree_easypost.rb
@@ -1,4 +1,5 @@
-require 'spree_core'
+require 'solidus_support'
+require 'solidus_core'
 
 module Spree
   module EasyPost

--- a/lib/spree_easypost/factories.rb
+++ b/lib/spree_easypost/factories.rb
@@ -6,13 +6,15 @@ FactoryGirl.define do
 end
 
 FactoryGirl.modify do
+  factory :address do
+    lastname "Doe"
+  end
+
   factory :variant do
     weight 10.0
   end
 
   factory :shipment do
-    address
-
     transient do
       inventory_units 1
     end

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'solidus', ['>= 1.1', '< 3.x']
+  s.add_dependency 'solidus_support', '>= 0.1.1'
   s.add_dependency 'easypost'
 
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'solidus', ['>= 1.3', '< 3.x']
+  s.add_dependency 'solidus', ['>= 1.1', '< 3.x']
   s.add_dependency 'easypost'
 
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'solidus', '~> 1.0'
+  s.add_dependency 'solidus', ['>= 1.3', '< 3.x']
   s.add_dependency 'easypost'
 
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/spec/cassettes/Spree_Address/_easypost_address/1_1_1.yml
+++ b/spec/cassettes/Spree_Address/_easypost_address/1_1_1.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=215%20N%207th%20Ave&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '221'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - d3b97494-d901-4f2f-b23c-a9c162b5bd59
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_8033df9eb5e24877891691a2dad2700f"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.020183'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web11sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQu27DMAxFf8XQnACSbNePLWinAM3SduliMBYNq5AlQ6bd
+        R5B/r2QHGbpUE3l5dC/BC9OK1QyUb0qepqqr8JyjzMqiKCvxUAmQCpQsOO/Y
+        jrnzB7YU+INSHqcpSK1HIFQNRFlyUex5vufyVfI6y+o0ew/MPKp/GQsDhunR
+        9TZ5chid3TCC/Q7i463asYk8IoloI/LklBTUJ4cF7xMZJifnqf/EiaKHpmjw
+        DHbRxmxcWCVSx9D86DGUvCzTfA2cLfnIv72EduydjWS+Pi6qKog4gDastrMx
+        OzY4FQG6ZYH3Gn3TQavNmrtR4VBaoSUN948dKvRgGoKvJt5/U9fV/mgLet3p
+        Fkg7O7H6cr3+AgAA//8DAJtia7ayAQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:34 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Address/_easypost_address/1_1_2.yml
+++ b/spec/cassettes/Spree_Address/_easypost_address/1_1_2.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=215%20N%207th%20Ave&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '221'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 000d2730-9ed8-4e9c-8d92-459651b930a4
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_1697e4be2a134822bdd537fabd5aa625"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.026317'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web4sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQPW+DMBCG/wrynEhgcPjYonaK1Cxtly7owIdwZGxkDvoR
+        5b/XhihDl3q6e+/x+57uypRkFQPp6uRQ5pg1yCFJs4LzRkqR5h00UgAcuGA7
+        ZpsLtuT5o5QOp8lLrUMglDUEmcdJvo/FPuZvPK6yrEqzD8/Mo/yXMTCgn55s
+        b6Jni8HZDiOYby8+3asdm8ghUhJsEhGdo5z66LjgY8L95Gwd9Z84UfBQFAxe
+        wCxK643zqwTq5JsfNfoyLopUrIGzIRf491ffjr01gRTri5Oy9CIOoDSrzKz1
+        jg1WBoDuWeCcQld30Cq95m6UP5SSaEjB42OHEh3omuCrDvff1HW1P9qCTnWq
+        BVLWTKy63m6/AAAA//8DAJla1biyAQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:34 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_EasyPost_ReturnAuthorization/_easypost_shipment/1_1_1.yml
+++ b/spec/cassettes/Spree_EasyPost_ReturnAuthorization/_easypost_shipment/1_1_1.yml
@@ -1,0 +1,607 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 0d8a0fe8-f719-404c-8496-17a6c3de6567
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_4fe660104d9848d1ad89158ddb9100dc"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.017612'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web15sj
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFfyXQnACSY6e2t6KZArRDH0sXgzFpmIUsGbKS
+        PoL8eyknyNClmsjLo8sL6aQYVa0AQ5N3tNloo3OsyrxEA1hWpigR95XRGlu1
+        VH7/QW0U/h4x0DSJ1AaCSNhAkjNt7la6WOnsNdN1ntfr6l2Yw4j/Mg4GkunO
+        926x9ZSc/TCC+xbx4Vot1RQDUTQpwWLLXUeBXFw8e8DbMJPhkw+x/6QpJhuO
+        yeMR3JGtpZmTNInaSfPDo5S6LNfFvPPgYkj824u0Y+9dIov5aFNVItIAbFXt
+        DtYu1eAxAfG6C0JgCk0HLdt574WSt2KUpAy3ix0hBbBNhK8mfcFFnaP90Y4U
+        uOMWIns3qfp0Pv8CAAD//wMABfKNhbUBAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:39 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 79293b62-6285-4466-9a37-df1bf2c64deb
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_b44fec7cecae4512905eab862dea6905"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.018891'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web3sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQvW7DIBSFX8VibiTA2HG8Za3ULmmXLtY1XCtUGCyMrbZR
+        3r2XRM7QpUycw3fuDxdmDWsZmNj1Sg2o9xo1oKqEPPAKoW9qaRBqEuyJhf4T
+        dSL+aEzEeSZLR4SEpoNsSy72O17tuHyTvFWqLQ8fxCyT+ZfxMCJr/eIc1Qzj
+        BP57k3OKiElQVpSiOBVNOhfHFdn2Ih85myjEXsCv1rk7QI3Jen0m8WMnuvKm
+        KfMuOiw+xcy/n0hO5+DxNp5UVS3okIkjWLdVH4PJQMI55TjEaDF2A2jrbn3v
+        FH2LNeiThUdwQIMRXJfgq8u/vW1Fo/3xVox2sBqSDX5m7eV6/QUAAP//AwAs
+        XyQSoAEAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:39 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10.0
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '19'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - c852453b-c87a-434c-b81a-bb672f8e4c92
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_faa5b6ffcb56402b8f44808048edebd2"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.041291'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web6sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SOzQ7CIBCE32XP1WwJrYSn8ODJSwPs0qLYEqTxYHx3MfHn
+        6HFmvpnMHQKBhpRdHLwxne29d7brJQqrvJQKFUrFxJYENLDYE7tSC3uTHcfq
+        uMymMA3m5QpsdxvsNigOArWUWuKxMmuiv0zkeSwT6HmNsYFboJ+YOIxT+aiU
+        6xsf5rqXjDubkb+lN9fiFhu4LFQTKHwt8HgCAAD//wMAVoPvIOcAAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:40 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[to_address][id]=adr_4fe660104d9848d1ad89158ddb9100dc&shipment[from_address][id]=adr_b44fec7cecae4512905eab862dea6905&shipment[parcel][id]=prcl_faa5b6ffcb56402b8f44808048edebd2
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '184'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 0cafb14c-0b72-4373-bfb9-45135508b6c5
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_69e9f5dc433346fc80bd73d30e00443c"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.223121'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web14sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xYS2/cNhD+KwuenQUpkXrszajbQ4AGRtz20CIQ+BjtstFS
+        AkXZcQL/945ea9lO4g3gODWQPYnDmeFwvm9Go/1EtAcZwBQykA2JKEtfUfGK
+        Rn9EdMP5htO/yQmxbeEhdN6RTSmrFk7IHtpWbqElm3/e4ao2gNYB2oDadRNs
+        7XDrE9Gd9+D0NW7+eXGGe5VUUBUGTyQb11XVCemfC2kupdMoozcnxEMJvdVB
+        pQ0ydOiPdO69q68c+gle6vfWbQs9HD3qdY159CpKBr0rrJltxvV8wlI2XXEW
+        6q4N9b4trCvrWVb6eo+xG4+q/XV7t0QaXyjOS9CpBi2BCxblVIBUWRIZkAku
+        +iypf0H3gZ5O9iePQBHnffxfv+Oo4+T+Nux630h3fZtKDxAY2rKYrS5WWdit
+        Ti+BzDvRwc6GHrXfpbu0VTUqDKiRN69x8dE2+EizLO7vouvOBT+ijMtmVzsY
+        wou4SBj+UAh7aavZ+13CaOm9BV+UUttqOHfUwrRYAy5YeTAswYCXVRHkhwWI
+        Q2j3ZJfgbWm1nLl4g8yyru28XDCr9uhuYdRIr6E6QNl4XWFUUqikLLUSCaeR
+        ykrOM5pRnmEsykRLLM9H+8egHKl4DF0rcNuwm8O7suZ2sQO73YVD5B6jKa1D
+        fw2WxoK4V5Meo2t6N/OYkabG3G2hGOrykHcMq6/sKQv9soglNTIRSOFMc26U
+        FHj9OC2zCGhaxrDMwtueKE+Xg7tkacFf2h5B8uuHZi6ckUAD/857BvqRqhFb
+        s6zfv9+GsJshG4tZLV6n4lb6sGnZNhT3XA6yB5oGKovEu8YOd31oJwvhou0t
+        hcW2k8jLAGAOHRZvW3zWXbuzzR6rYqAtrpoiySEvhdE8jmOelDqjyqSxiSlQ
+        ynmsFyUm9VCro62WxT4owf4CilxYop0Llhml01hBzqFM8jhFSSZiGYsclz8A
+        7d+sXzaLB1jHa548DvU3ID05PAro6AlRjp4H4iTXJjY6pZqnXGZZzvBFxRPF
+        U61yPO0HQHzube37/v9llMWI3yMoJ+vkWJTFOhfHosyeEGX2PCgbo3XKWKS4
+        wEGERzKKEiFFGgmlpB48PjvKwzvyAqr+1K8hnR+B9KT11Ei/jHp+N8zKnTP3
+        5tdWS1eUtd8fBEOyES+/uMswQveJn5b1ZydZnGOThDLKTZ7xzDBpsFOIzBiV
+        M0rNHQJ9r0mWvK53bnVWD+yc51nyy/S0HGpPV2e2HL4ewuptLc1yriVvah92
+        V9PI+QTjrRh+lOX5/2S87dqmLT4OwbGhJvCL7efnycv5PFHddV/vP6vwRVdh
+        33in/0VKmP8h+ZbGf0DyYnptkJv/AAAA//8DAHOar4qnEQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:40 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - af6f56a9-004e-4df2-b69c-3ebfdbd2d760
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_52f1c185c01440bcbedef52848f95a66"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.017244'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web3sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQMW/DIBCF/4rF3EhAwKXeslZql7RLF+sMZ4UKg4Wx1TbK
+        f+85kTN0KRP3+N7d487MO9YwcLnVshdWGG25UIp3tkOHvZZGmf5JQ12zB5a6
+        T7SF+INzGaeJJJsRCroWVlly8bjjesflm+SNUo3iH8TMo/uXiTAga+IcAvVM
+        wwjxeyunkhGLIK/Yi+pYmXKqDguy7UXefb6Qib1AXHwIN4AGk/T6TMWPH+nK
+        jdnrNXiaY8kr/36kcjyliNd4Uula0CERB/Bh6z4ktwIFp7LaIWePue3B+nCd
+        e6NoLd5hLB7uxp4WmSG0Bb7addvbryjaH23B7HtvofgUJ9acL5dfAAAA//8D
+        AMrAJCygAQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:41 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 9a027f03-df85-4671-b50d-ec36d12b6804
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_601e8c2902a34053b3c849015a765f8e"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.017435'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web4sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFf8XQnADyK7G9Bc0UoB36WLoYjETDLGTJkOX0
+        EeTfSzlBhi7VRF4e8V5IZ0FaNAK0bzcyxUpltcwgL2SZH3NVFbVMS9huyq5C
+        sRLu+IEqML/T2uM0saQ8QkDdQpQzmW7XslzL7DWTTVE0RfrOzDzqfxkLA/L0
+        4Hqb7F00U24YwX6z+HCrVmIKHjGkMUGyp65DjzYkzw70fZjx8Mn50H/iFOIa
+        CnHHI9gTGYMLx2kideDmh0YuZVXl5eI52+Aj//bC7dg7G8lyOTKtaxZxADKi
+        sbMxKzE4HYFw8wLvCX3bgSKz+F4pfivSnJTgfrFDjR5MG+CrjV9wVZdof7QT
+        eupIQSBnJ9GcL5dfAAAA//8DAKDhYjy1AQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:41 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '17'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - d0dac3cd-ce99-4ac5-9017-ca476034f769
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_30305f03e5cd4d50b71e871e5b716fa1"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.015175'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web14sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMvQ7CMAyE38Vzi5w2oShPwcDEUqWx2wZCGoVUDIh3J0j8
+        jAwn3Z2/8x0cgYaYrO9bbFGN2LKyJEnh0AneFalitqMRUMEynNjmMtibZNmX
+        xiY2mak3r7ZB0dWoamwODWoptRTHwqyR/jKew5Rn0GH1voKbo1+Y2U1z/qSY
+        mHh0ofyLxp7NxN/RmxO4wQouC5ULZL5meDwBAAD//wMAGJFPzOcAAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:41 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[from_address][id]=adr_52f1c185c01440bcbedef52848f95a66&shipment[to_address][id]=adr_601e8c2902a34053b3c849015a765f8e&shipment[parcel][id]=prcl_30305f03e5cd4d50b71e871e5b716fa1&shipment[is_return]=true
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '209'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 3ac008e6-87ff-4fd0-adbc-f28986999b27
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_e427e1c0ded449d4bfd56373fa1f50b1"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.221392'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web14sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xY32/bNhD+Vww9pwYpkfrht2DZHgqsCJptDysKgSKPNleZ
+        EigqaVrkf9+Jkhwl6WZ3CJoVqAED4vGOPN733fGkz5F0IDyoUvhoE8WEZq8I
+        f0Xi32KyYWzD6J/RWWS60oHvnY023vVwFu2h68QWumjz7j2OGgVo7KHzqNy0
+        3jQWpz5HsncOrLzFyd+vLnCuFhXUpcINo43t6/osGp5Loa6FlSgjd2eRAw2D
+        1UGl88L3uF7U2w+2ubG4jndCfjB2W8qw9ajXt+roSSrh5a40arYZx/MOS9l0
+        xFko+843+640VjezTLtmj74rh6rDcYdlI6FcyWNNJc25JJQxUskKFGge5yzX
+        BRdpOkSp+gvk4Oj5ZH92DAky+H/kjEHHiv29282+Ffb2PpQOwFO0pQldXa1y
+        v1udX0M0z8QHO+MH1H4V9trU9agQUIvevMbBJ9PiI8nzhA+ON731bkQZh+2u
+        sRDcixlPKf5QCHth6nn1h4SRwjkDrtRCmjrsO2phWIwC6404GGoMpBN16cXH
+        BYjBtUeya3BGGylmLt4hs4zteicWzGocLrcwaoWTUB+gbJ2sy4QkhGuSAJeK
+        KU6qjEKOf44PqRZ0ieXlaH8USnoClEGnBrv1u9m9G6PuBzsw250/eO4GihmL
+        67WYGgvi3kx6lKzJw8hjRNoGY7eFMuTlIe7o1pDZUxSGYZkoSTQhnCeVZKJK
+        qpRXcUZFAmmhOX0QhbcDUZ4vBg/J0oG7NgOC0c8f2zlxRgIF/l0ODHQjVWO6
+        pvkw/7gMYTFDNpazWrLO+L30adEynS8fLRlkTzQV1AaJd4sV7vZQThbCRdlb
+        CsttL5CXHgDjrUXdYYXF05ZfXK7bmXaPWRFoi6O2BBZnQCVRoBgrFKu04mmS
+        JUhOjXylixQTMuTqaCtFufcVp38AQS4s0WZVxguQnMSxZrJiWMmoUqogFUvy
+        qlAvgPYvxi2LxROskzVLj0P9FUhPC54EdPyMKMffBmLIVKFzYDmmMBNMFDIB
+        mmMqQ8byCooXgPjSmcYN9f+fUeYjfkdQTtfpqSjzdcFPRZk+I8r026CcZhyU
+        0JmmiWAkrgqCt3FWZNiNMIpl/CVQDnfkFdTDrv+GdHEC0pPWcyP9feTz+9Ar
+        91Y96l87KWypG7c/CEKwES+3OEtooYfAT8Pmi51sSrDbkXFBYpEwgrd/InOG
+        LOIiSznWj//UyZ7MobGTjV43O7u6aAI75342+ml6Wja156sLo8Pbg1+9bYRa
+        9rXRm8b53c3Ucj5De8vDj9Ci+J+0t33XduWn4BwNOYEvbD9eT76f15Oqvx3y
+        /UcWftdZOBTe6buIhvkLydcU/gOSV9O1Ed39DQAA//8DAFqCb42mEQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_EasyPost_ReturnAuthorization/_return_label/1_2_1.yml
+++ b/spec/cassettes/Spree_EasyPost_ReturnAuthorization/_return_label/1_2_1.yml
@@ -1,0 +1,704 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - b51621a9-e893-44ad-ac08-c4047adafcd8
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_379981d205194a6b84e11e4f6ccf4ba1"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.018418'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web4sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRPW/CMBCG/wryDJIdHEiyoTIhtUM/li7REZ/FVY4dOYZ+
+        IP57zwExdKmnu/cev/fKPgsyohFgYrtc13WlTCFLVWtY7SuNSqG2q66zeg9K
+        zEXYf2CXmN8YE3EcWeoiQkLTQpYLqdYLWS5k8VrIRutGF+/MHAfzL+OhR57u
+        wsHPtgGzc+gH8N8sPtyquRhTREwqJ5htyVqM6NPsOYC5DwsePoWYDp84pmxD
+        KXs8gj+RczhxnCZTO25+aOBSVtWynHYefYqZf3vhdjgEn8lyOlLVNYvYAznR
+        +KNzc9EHk4F02wUxEsbWQkdu2nul+K3IcFKC+0WLBiO4NsFXm7/gqk7R/mgn
+        jGSpg0TBj6I5Xy6/AAAA//8DAC2bZYm1AQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:42 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - c5b15bd9-1ea7-4de8-bebd-8fd5fdd929bb
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_bc98fb84c8da466b9676106135e80fe4"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.022951'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web11sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQMW/DIBCF/4rF3EiAsUO8Za3ULmmXLtYZzgoVxhbGVtso
+        /71HImfoUibu8b27x12Ys6xhYGPbmYPuO62MtqDqujvU+1rwWpQVat6jYk9s
+        7D7RJOKP1kacZ5JMREhoW8iy5GK/49WOyzfJG6UaJT+IWSb7LxNgQNaExXvq
+        OQ4ThO+tnFNETIK8ohTFqdDpXBxXZNuLfPhcIhN7gbA67+8ADSbp9ZmKHzfR
+        lWtdVjn4uIQUM/9+onI6jwFv8aSqakGHRBzA+a37MNoMJJxTtkOMDmPbg3H+
+        NvdO0VqcxZAcPIw9Wozg2wRfbd729iuK9kdbMbreGUhuDDNrLtfrLwAAAP//
+        AwAWqSEvoAEAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:42 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10.0
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '19'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 4cfebb72-9c95-4e5e-b44a-61304f0c98be
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_f59417e6c55845668c6c5601c8e031af"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.015229'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web14sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMOw7CMBBE77J1QOtgO8GnoKCiicx6kxhMYhlHFIi7YyQ+
+        Jd183swdvAMDMVHoerWVomFNSrVSad1SkRoFtYwbYXuoYD6emHIZ7GwiDiWh
+        xDaz6+wrrVE0K1QrrPc1GimNrA+FWaL7ywSehjyCmZYQKrh59zMj+2HMHxcT
+        O+79VP6ipbMd+Dt6cwLXWMFldqWBzNcMjycAAAD//wMAvDDtZ+cAAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:42 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[to_address][id]=adr_379981d205194a6b84e11e4f6ccf4ba1&shipment[from_address][id]=adr_bc98fb84c8da466b9676106135e80fe4&shipment[parcel][id]=prcl_f59417e6c55845668c6c5601c8e031af
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '184'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - a32be5ae-4da3-40b4-adbc-c3f878e5d3cd
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_8b3d8a0bcbff4a64972a63e02b83f4cf"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.205830'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web3sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xYUW/bNhD+K4aeU4OkKJr0W7BsDwVWBM22hxWFQFFHm6tM
+        CRSVNC3y33eSJUdJusUFvGYF6ifxeHc83vfd6eTPiQmgI5S5jsk6YYSuXpHs
+        FWG/MbLmfM3Zn8lZ4to8QOyCT9ZWVy2cJTtoW72BNlm/e4+rugS0jtBG1K6b
+        6GqPW58T04UA3tzi5u9XF7hX6QKqvMQTk7Xvquos6Z9zXV5rb1BG7s6SABZ6
+        q4NKG3Xs0F/S+Q++vvHoJwZtPji/yc1w9F6va8pnr1LoaLa5Kyeb/Xo6YS4b
+        rzgJTdfGetfmztt6ktlQ7zD2MqBqf93ebaLLkBdGSVtIbmSpuRCFEitBiaBp
+        BpJY4H2Wir/A9IGej/ZnR0FxzB293t2HXe8a7W/vUxkAIkVbmtLF1ULG7eL8
+        GpJphx3sXOxR+1X7a1dVe4UBteTNa1x8cg0+EinTrA+87nwMe5Rx2WxrD0N4
+        jGeC4g+FsNOumrw/JIzRITgIudXGVcO5ey1MiyvBR6cPhhZKCLrKo/44A3EI
+        7ZHsGoKzzuiJi3fILOfbLugZs+qA7mZGjQ4GqgOUTTBVbjPF6QqEyTKJ1xHS
+        4KMg1EggKdV2juXl3v50UFbgN3E7hXfjyvvFFtxmGw+RB8yMdR79NVgaM+Le
+        jHqULMnDzGNGmhpzt4F8qMtD3jGsvrLHLPTLnMHKWG01Y1LwlREKOW0V8twU
+        HCSn8yy87Ylyuhw8JEsL4dr1CCY/f2ymwtkTaODfZc/AsKcqo0sq+/3HbQi7
+        GbIxn9TS5Sq7lz5tWq6N+SOXg+yJZgmVQ+LdYoe7PbSTmXDW9ubCfNNp5GUE
+        KA8dFm+bf9Fdu3XNDqtioC2umlwWaSk1KUxhLdeCqxXTIgXCCplabuysxLQZ
+        anVva3S+i0VG/wCCXJijnVIFiisqjaK8BFCGKCkKueJGEC7sC6D9iwvzZvEE
+        63TJxfNQfwXSo8OjgGYnRJl9G4gN9jRJmVVcSA6ZlVlKLKNCiIyXKpUvAPFl
+        cHXo+/8/o5zt8XsGZbEUx6KcLVV2LMr0hCjTb4Myo0SbgkDGmOBZQaVQElYZ
+        ADUlvrzZS6A8vCOvoOpP/Tek1RFIj1qnRvr7qOf3w6zc+fLR/Noa7XNbh91B
+        MCQb8QqzuwwjdJ/4cVl/cZJNV0pJWjKSUYWB4kwLlAK3whjLC/3gvf9fTbLJ
+        63rrFxf1wM5pnk1+Gp/mQ+354sLZ4eshLt7WupzPtcmbOsTtzThynmC8zYYf
+        oUr9T8bbrm3a/NMQHB1qAr/YfnyefD+fJ0V329f7jyr8rquwb7zj/yIWpn9I
+        vqbxH5C8Gl8byd3fAAAA//8DACLV1Y6nEQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:42 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - b750fa63-ad5e-41c4-ba3f-e7ada38140e0
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_0ce6bd768fb5475e9652d2db0acfc5ea"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.015773'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web11sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQMW+DMBCF/0rkuZGMwUDZslZql7RLF3T4DsWRsZExqG2U
+        /94jERm61JPv+Xt3z3cRFkUjAGMrDZUdVmXdd7qoND2XWqHCToLpjSYQTyJ0
+        ZzKJ+QNipGliyUSCRNjCKiuZVXup91K9K9kURVPkn8zMI/7LeBhINH52jnuG
+        YQT/vZVTikQpY2+WZ7vjrk6n3WEhsb2oh88mNolX8It17g7wYJbeXrj4sSNf
+        ZV3neg0eZp/iyn8cuRxPwdMtnip0mfFhkQawbus+BFyBRFNa7RCjpdj2YKy7
+        zb1TvBaL5JOFh7EnpAiuTfDVrtvefsXR/mgLRdtbA8kGP4nmcr3+AgAA//8D
+        ADYK2JqgAQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:43 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 615b5d91-f6af-4787-820e-b36a56f6b44f
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_d7f4bd1678954c2f9e66b263e1984a0e"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.023790'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web15sj
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFfyXQnACy4/cWNFOAduhj6WLQFgWzkCVDVtJH
+        kH8v5QQZulQTeXnEeyGdBSnRCFC+VaXOOpUUZVXnWZ/qGouiS4stJnWVgUSx
+        Fq77wD4wv1PK4zyz1HuEgKqFKKcyKTcy38j0NZVNljXZ9p2Z46T+ZSyMyNOD
+        G+xq76JZ78YJ7DeLD7dqLebgEUMSE6z2pDV6tGH17EDdhykPn5wPwyfOIa6h
+        EHc8gj2RMbhwnCZSB25+aOJSVtU2XzyPNvjIv71wOw3ORjJfjkzqmkUcgYxo
+        7NGYtRidikC4eYH3hL7V0JNZfK8UvxUpTkpwv6hRoQfTBvhq4xdc1SXaH+2E
+        njT1EMjZWTTny+UXAAD//wMAS+WterUBAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:43 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '17'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 956bdbb2-66e8-4075-8cca-72af19c57cec
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_2d1af804fe9e49b090e775db7c8d2551"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.013684'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web4sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMOw7CMBBE77J1QGtjy0lOQUFFEzneTWIwiWUcUSDujpH4
+        lJTz5s3cwRO0EJMLnSRhhxrVwA2rpscG2RhNvXE1Sa0FVLD0J3a5DPY2OQ6F
+        uMQ2M3X2RSUKs0G9QXmQ2CrVqt2xOGukv07gecwTtPMaQgU3T78wsR+n/Ekx
+        MfHg5/IXrTvbkb+jtydwixVcFioNZL5meDwBAAD//wMATV683ucAAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:43 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[from_address][id]=adr_0ce6bd768fb5475e9652d2db0acfc5ea&shipment[to_address][id]=adr_d7f4bd1678954c2f9e66b263e1984a0e&shipment[parcel][id]=prcl_2d1af804fe9e49b090e775db7c8d2551&shipment[is_return]=true
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '209'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - cdbf20cc-87e3-4386-a3fe-d09b4abfc799
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_76daef2727dd420798f2e3ad35ca64a3"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.193512'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web11sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xY32/cNgz+Vw5+Tg+yLPnHvQXL9lBgRdBse1hRGJRE32n1
+        yYYsJ02L/O+jfeeLk3TNFUibBeg9WRRJUfw+0vR9jrRHCGhKCNEq4izOXjH5
+        ivE/OFsJsRLJ39FJZLvSY+i9i1bB93gSbbHrYI1dtHr3nlaNQTIO2AVSbtpg
+        G0dbnyPde49OX9PmnxdntFeDwro0dGC0cn1dn0TDcwnmEpwmGbs5iTxWOFgd
+        VLoAoSd/Ue8+uObKkZ/gQX+wbl3q8eidXt+aR2+iIOhNac1ks1tPJ8xl+ytO
+        Qt13odl2pXVVM8kq32wpduNJdbju4DYC40umMVUmS/NKSZFJLFLJDTeKga60
+        RBiypP5BPQR6urc/OQqJY+7oYHsbdrNtwV3fptIjhphs4yReXCzysFmcXmI0
+        7fCDnQ0Dar+Du7R1vVMYUYvevKbFJ9vSI8vzRA6BN70LfocyLdtN43AMjwuZ
+        xvQjIW7B1pP3u4TR4L1FX1agbT2eu9OitFiDLlg4GFZo0ENdBvg4A3EM7Z7s
+        Er2trIaJizfELOu63sOMWY0ndzOjFrzG+gBl63VdchNDlTNRYYGiUKxgmGXS
+        qEznhksZz7E839k/HZQ1unXYTOFdWXO72KBdb8Ihck+Zqawjfy2Vxoy4V3u9
+        mC3Z3cxTRtqGcrfGcqzLQ94prKGy91kYlqXgRWxQxlDkUjAZF6YqEDApQGqS
+        4DwLbweiPJoDcUQORp27ZOnQX9oBwejXj+1UODsCjfw7Hxjod1Tl8TLOh/37
+        bYiaGbGxnNSSZSZvpQ+blu1Cec/lKHugabC2RLxr6nDXh3YyE87a3lxYrnsg
+        XgZEyncFdUcdlm5bftFdt7HtlqpipC2t2jJLDWDFM54ZIzjLirzimIBJpIZU
+        QDIrMdBjre5sNZTboGT8FzLiwhztJMuTgtpVhuRApgqUTlOBdIwyeRyLZ0D7
+        N+vnzeIB1slSpI9D/Q1I7x0eBTR/QpT5j4GYMc4TkfNMaCMyrpSEAgumOGag
+        VaKfAeJzbxs/9P//Rlnu8HsE5XSZHouyXBbyWJTjJ0Q5/jEoI6uMTplOFBfU
+        wjkoniNQAyf4K5Wlz4Hy+I68wHo49WtIF0cgvdd6aqRfRj2/H2fl3pl782un
+        wZVV47cHwZhswsvP7jKO0EPi98vmi5OsySqhTJxmeSGF5vTST1PF0wTjIhfA
+        7rz3v9ckG71uNm5x1ozsnObZ6Jf903yoPV2c2Wr8egiLtw2Y+VwbvWl82Fzt
+        R84nGG/l+GNxUfxPxtu+a7vy0xhcPNYEfbD9/Dx5OZ8nqr8e6v1nFb7oKhwa
+        7/5/kQqnf0i+pfEfkLzYvzaim38BAAD//wMABTbET6YRAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:44 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments/shp_76daef2727dd420798f2e3ad35ca64a3/buy
+    body:
+      encoding: UTF-8
+      string: rate[id]=rate_4291de51a98540519df9eae39a5c854e
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '46'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - b3d7c8a6-af12-4d06-891a-39aa3e0f14b6
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '1.018328'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web3sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xYbW/bNhD+K4E+Jw5FkXrxt2JpMRRL0K3JtmYoBIo82Upk
+        SaCouHaR/76jXmzZSRsPCxp0q79YPN6Rx3uOd7z77EgNwoCKhXGmDiVucEL4
+        CaGXlEwZmzLv2jl2sjrWYBpdOFOjGzh2FlDXYga1M/3rI45KBShsoDbIXFYm
+        Kwuc+uzIRmso5Aonr96f4VwuEshjhRs606LJ82PHfsdC3YlCIo3cHzsaUrBS
+        G5baCNPgek5T3BblssB1jBbyNitmsey2jlhAXM8PoyBkvksC3w2RgoxNpb52
+        Om5Plwgj53Gmhv268bDrmNYfeyDKpjbloo6zIi0HWqrLBZ5HaWS1JrDLOkLp
+        mEjwExX4YZpwFnCIfE4VVQkRMpUchLVccgPSKvqqlz8+CJ0nzsgsTyEWW7XL
+        RSWK1da8GsC4KOt67tH7o9DMj17dgTPM0I1cZiyS56K4y/K8Y2iRdC7e4mCd
+        VfhJwtDjJ27gcqt92RRGd/DjsJqXBbQ6UsZ9F39IhIXI8mGLXU+SQusMdJwK
+        meXt5h0X2iZTUJhMbARTUKBFHhvxaYRkq98e7Q50lmZSbJwU9Wb2v26kbEHr
+        XBy0LnXv4AoMKtk7w/09OmlW1I0WIyctNSow2qYSWkK+8YBKyzymyhVpSFgK
+        EbAoIRGBIOAqCWSoKOfu2AXedfLP4gEtTw7FzMwH9ZaZ2g7mkM3mZqO5Rlum
+        WYHrVXjLRv6+7PlcMiG7WKFFqhKtPYO4veL23NujdDO/tBPHvT3yOOGJ5wNL
+        OUOTKOARYUSkRHq+JJGMoqfPzg44e3vD94KMhc/ATLdyaakXKFlY19wNUF/a
+        seNBJyzzxnqRM/UIGch1trai7JO/4TSrypLQqKLJzYacZjkMc9kCDXRaFbPN
+        bKPRiM7cmKqenp6CqFfWwCdWqJ7U3klTnyzR8id0IhZiXRZiWU/wYp+2DKc7
+        YJzacxBO6KknXSkgUpL5EZM0SSgLXJcxP02DMBR0MtagUmmnRQd+R1xX+UMi
+        VDl9SLWa9DcGryxa1F6m/jrYYcxo5CLurohCzgh3I5VGIMCLBJdIgfF1+M0i
+        8iwO0fLsxpka9F1mPcN5/akaAm8Xe9rQ9c4GL937hDtxQzu/n9p0GyPigc2b
+        BHxLfZgIs9rEe0u2tAecCvIMY9YKnXK1SUcj4iiVjonxrBEYoAwA2jsVeW1D
+        Gq7/6HL1PKsWGFDb+IWjKg58JSClAQ2UYpQEUZhS8ITyuBQ+E94oOgvZhvlO
+        Vop4YRLu/g4Eg8IYbS8IvQjTXQC4APcTkUjfZ4DbJCpEJ3wBtN9kepxnHmDt
+        TZj/NNT/AOl+wYOAps+IMv02EBNCqcdCGjCpWIDhhYsIIpJQCIRMPPkCEL/T
+        Want0+HLKPMOvydQ9if+oSjzScQPRdl9RpTdb4MykFRJH/M0Zg8M4VQkNASB
+        ARzhT5PAfwmU28fSe8jtrl9DOjoA6Z7ruZH+Pu7zx7b+agq1V//UUhT9U6kn
+        tMZGvDpT/Mjr/6e83tXf1oo97kbfxmFCI+lzP+VUMgIQCU8pP3Sx2g2J6+7E
+        hctefh+xg+v6R3oCHSnuarWdmSe8ix9aRtTZzFZFyWq/IOpGezBsAfw3MGwd
+        dWObTTVqS9MUhi7MgNtggL6aa5I8k3vlRLvUZCgq2rpB3bz21c9v9Z/reXZ+
+        k99c3FzR65ur1Yf1r8vrP674h8uL2+uzD+z88opcrGfL88vXtPWE8tFuhwpS
+        lijXD8KIY6WBAcD3E+p74EYhE2QnBjxrt8Pbdjuct+W8ODor2wAz9Dycn/qv
+        cePj1dFZlrZdJ3P0WynUuPfhXJTazJd9R+LgFsiXux+8/RG3rXBfuvthexlN
+        XdXxulXObSNbo4sfLaz/fAsraVY2yv+4vN/15bVvst1UMOq8vQF7yr7H1Pbf
+        OopY2NPZ006IR4hNqHIu9My+KTrX6R6BmzeGrQAeX7Vv7u2t2z59Dlr4Y98Q
+        PDArbpR43+dU5/5vAAAA//8DABjGMIPDGAAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Shipment/_easypost_shipment/it_is_a_new_shipment/behaves_like_an_easypost_shipment/1_1_1_1_1.yml
+++ b/spec/cassettes/Spree_Shipment/_easypost_shipment/it_is_a_new_shipment/behaves_like_an_easypost_shipment/1_1_1_1_1.yml
@@ -1,0 +1,306 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 5e97b873-23e7-4799-8b61-f97c10f5efe6
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_fa33ea35bbf14f9f8ffa18c16f6af55b"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.018644'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web3sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFf8XQnACWH6ntrWimAO3Qx9LFoC0KZiFLhiyn
+        jyD/XsoJMnSpJvLyiLwgT4KUaAQo32rIc4S87DotC13rSmuQVS93ege6LDux
+        Ea77wD4wf6+Ux3lmqfcIAVULUc5SebdNy22avWZpUxRNLt+ZWSb1L2NhRK4e
+        3GCTvcPY2Y0T2G8WH67RRszBIwYZHSR70ho92pA8O1C3YsbFJ+fD8IlziG0o
+        xB6PYI9kDK4cu4nUgZMfmjhMqyov15mLDT7yby+cToOzkSzXl8q6ZhFHICMa
+        uxizEaNTEQjXWeA9YVxlT2ade6F4V6TYKcHto0aFHkwb4KuNJ7ioq7U/2hE9
+        aeohkLOzaE7n8y8AAAD//wMAFPnFRLUBAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:31 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 1e1876fa-ba8b-489b-a3e5-b49960ddb728
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_e5c6d66e7d79473da6bbf5aa372118e7"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.060137'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web15sj
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQvW7DMAyEXyXQ3ACW/CPXW9YC7ZJ26WLQJo0okCVDlo22
+        Qd69VAJn6FJN4uk78sSLMCgaARhaKvsKq4o06udC5whV1w0lQK6VlDVp8SR8
+        d6Y+Mn9ADDTPLPWBIBK2kGSVSb3Pyn2m3lXWFEWTq09mlgn/ZRyMJBq3WMs9
+        /TiB+97KOQaiKNkrc7k77up42h1WEtuLevhMZJN4Bbcaa+8AD2bp7YWLHzPx
+        NavrvEzB/eJiSPzHkcvp5B3d4qmirCQfFmkEY7fuo8cERJpjskMIhkI7QG/s
+        be6d4rUYJBcNPIwDIQWwbYSvNm17+xVH+6OtFMxgeojGu1k0l+v1FwAA//8D
+        AKqXtVegAQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:32 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10.0
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '19'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 286c5f48-a8b8-4e64-8d00-5411f8a83bc1
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_41833a4f0d384e30b648f0faee828842"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.040679'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web6sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMzQ7CIBCE32XP1WwBlfAUHjx5aSi7tCi2BGk8GN9dTPw5
+        epxvvpk7BAIDKbvYqVZLaZVHklqxxH6rtEdvmbXQWgloYO5P7Eod7G12HCtx
+        mW1h6uyLCmx3K9ysUBwEGqWMFMfqLIn+OpGnoYxgpiXGBm6BfmHkMIzlk1Jm
+        Yh+m+pesO9uBv6O31+IaG7jMVBsofC3weAIAAP//AwBwpkGZ5wAAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:32 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[to_address][id]=adr_fa33ea35bbf14f9f8ffa18c16f6af55b&shipment[from_address][id]=adr_e5c6d66e7d79473da6bbf5aa372118e7&shipment[parcel][id]=prcl_41833a4f0d384e30b648f0faee828842
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '184'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - c87b7dd4-e023-4335-9bf0-7a1ba670ae13
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_2bbb0fb24d904bc69797986a52eceec8"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.207118'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web4sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xY32/bNhD+Vww9pwZJURLlt2DZHgqsCJptDysK4UQeba4y
+        JVBU0rTI/z7ql6Mk3eIORrMCtV/E493xeN9355M/R9IheFQF+GgTMUKzVyR5
+        RdhvjGw438Tsz+gsMm3h0HfORhsNVYtn0R7bFrbYRpt378OqVhisPbY+aNeN
+        N7UNW58j2TmHVt6Gzd+vLsJeBSVWhQonRhvbVdVZ1D8XoK7ByiAjd2eRQ429
+        1UGl9eC74C/q7Adb39jgxzuQH4zdFnI4etTrGvXsVUrwclcYNduM6/mEpWy6
+        4iyUXevrfVsYq+tZpl29D7ErF1T76/ZuI1CuwESmKk0xU1nOs1hBWpY6AYgz
+        RqnArM9S+RfKPtDzyf7sKCiOuaOF/X3Y9b4Be3ufSofoabClMV1drYTfrc6v
+        MZp32MHO+B61X8Fem6oaFQbUojevw+KTacIjESJO+sDrzno3ohyWza62OITH
+        eJLS8AlC3IOpZu8PCSPBOYOu0CBNNZw7aoW0GIXWGzgYalTooCo8fFyAOIT2
+        SHaNzmgjYebiXWCWsW3nYMGs2gV3C6MGnMTqAGXjZFVwKuIYuCYqFhxjUqZc
+        aKIBUTAhOFtieTnanw7KCu3W7+bwboy6X+zQbHf+ELkLmdHGBn9NKI0FcW8m
+        PUrW5GHmQ0aaOuRui8VQl4e8h7D6yp6y0C+LOOF5zpKSBT5zkEwQVHEGmSAp
+        50lOlll42xPldDl4SJYW3bXpEYx+/tjMhTMSaODfZc9AN1KV0TUV/f7jNhS6
+        WWBjMavF6yy5lz5tWqb1xSOXg+yJpsLKBOLdhg53e2gnC+Gi7S2FxbaDwEuP
+        qA4dNty2+KK7dmeafaiKgbZh1RSsLEuiS8ZVTngp0zwLX5FCwlAiSrEoMZBD
+        rY62Eoq9LxP6B5LAhSXaPM4hkSxXnBAucgJ5qijRmAgqUx7TF0D7F+OWzeIJ
+        1vGap89D/RVITw6PApqdEGX2bSBWKWPBVYyoGZeE5JhTXWqRkoxBzsQLQHzp
+        TO36/v/PKCcjfs+gnK7TY1FO1nlyLMr0hCjTb4NyLBiLORAoU+RUK5BIiKA5
+        CKIp0Jdo2+Nv5BVW/an/hnR+BNKT1qmR/j7q+f0wK3dWPZpfWwm20LXbHwRD
+        sgNebnGXYYTuEz8t6y9OshriGCFOwvxKuc610BqokDTVKegkKf/TJEuP4BC9
+        n2Sj1/XOri7qgZ3zPBv9ND0th9rz1YXRw9uDX72tQS3n2uhN7fzuZho5TzDe
+        JsOH0Dz/n4y3Xdu0xachODrURHhj+/F68v28npTdbV/vP6rwu67CvvFO/4to
+        nP8h+ZrGf0DyavrZiO7+BgAA//8DAPypnk+nEQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Shipment/_easypost_shipment/it_is_an_existing_shipment/behaves_like_an_easypost_shipment/1_1_2_1_1.yml
+++ b/spec/cassettes/Spree_Shipment/_easypost_shipment/it_is_an_existing_shipment/behaves_like_an_easypost_shipment/1_1_2_1_1.yml
@@ -1,0 +1,392 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 45e39ec3-f12d-4403-9ca9-df8ff267df31
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_6ff160106a3e4313b50bb7a40858789c"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.022117'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web15sj
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFfyXQnADyM463oJkCtEMfSxeDtiiYhSwZspw+
+        gvx7KSfI0KWayMujywvpLEiJWoDyTal1UspElpBhniVZW8i23UIuq6LaVrtO
+        rIVrP7ALzO+V8jhNLHUeIaBqIMqpTLYbWWxk+prKOs/rLHtnZh7Vv4yFAXl6
+        dL1dHRxGZzeMYL9ZfLhVazEFjxiSmGB1IK3Row2rZwfqPkx5+OR86D9xCtGG
+        QvR4BHsiY3DhOE2kjtz80MilrKqsWHbONvjIv71wO/bORrJYjkx2OxZxADKi
+        trMxazE4FYFw2wXeE/pGQ0dm2Xul+K1IcVKC+0WNCj2YJsBXE7/gqi7R/mgn
+        9KSpg0DOTqI+Xy6/AAAA//8DAOqpa6y1AQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:33 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 25a41279-d2d2-4c89-9284-b402bb13b077
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_c5c1e4610f224b579226cbaccc728acd"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.022617'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web15sj
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQvW7DMAyEXyXQ3ACS/FtvWQu0S9qli0FLNMJAlgxZNtoG
+        effSCZyhSzWJp+/IEy+CrGgE2NiawijMSyV7rfOuqJ61Lk0HxphK12CseBKh
+        O6NJzB+sjThNLJmIkNC2sMpaqmovi73U71o2ed5k2Scz82j/ZTwMKBo/O8c9
+        wzCC/97KKUXEpNirMrU77up02h0WFNuLfvgosUm8gl/IuTvAg1l6e+Hih0a+
+        yrrOijV4mH2KK/9x5HI8BY+3eDovSsWHRRyA3NZ9CHYFEk5ptUOMhLHtwZC7
+        zb1TvBay6BPBw9ijxQiuTfDVrtvefsXR/mgLRurJQKLgJ9FcrtdfAAAA//8D
+        AAwwuNygAQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:33 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10.0
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '19'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - d00a646a-6b66-4ae3-92f4-a359124a865b
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_c62eaa7b05b24e209bef7d979d649024"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.033699'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web5sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMOw7CMBBE77J1gjaOE8s+BQUVTeTPJjGYxDKOKBB3x0h8
+        Ssp582bu4B0oiMmGwfaMtBYGO8M4MZSGRuGkkK7nEhmHClZzIpvLYK+TpVCI
+        TaQzuUG/KMNG1NjVyA4MFeeqbY/F2aL76wRapjyDWrYQKrh59wsz+WnOnxQT
+        ORr9Uv6itmc90Xf09hrcYQWX1ZUGMl0zPJ4AAAD//wMAH76/PucAAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:33 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[to_address][id]=adr_6ff160106a3e4313b50bb7a40858789c&shipment[from_address][id]=adr_c5c1e4610f224b579226cbaccc728acd&shipment[parcel][id]=prcl_c62eaa7b05b24e209bef7d979d649024
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '184'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 3e0877be-2eb0-4ad6-83f8-89faf093a476
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_3fa366a52db149629db9b792ef84ffb7"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.196464'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web3sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xY3W/bNhD/Vww9pwZJkfrwW7BsDwVWBM22hw2FwI+jzVWm
+        BIpKmhb933eSLUdJusUFjGQBar+Ix7vj8X6/O5/8JdEBZARTyZisEkZo/oaI
+        N4T9xsiK81Wa/pmcJa6rAsQ++GRlZd3BWbKFrpNr6JLVXx9w1RhA6whdRO2m
+        ja7xuPUl0X0I4PUtbv5+dYF7tVRQVwZPTFa+r+uzZHiupLmWXqOMfD1LAlgY
+        rA4qXZSxR39J7z/65sajnxik/uj8utLj0Tu9vjVPXkXJqDeVM5PNbj2dMJft
+        rzgJdd/FZttVzttmktnQbDF2E1B1uO7gNpEmVFpoCjyjxDLGlchLxjKtpNY6
+        Z4XUZsiS+hv0EOj53v7sKCiOuaOX27uwm20r/e1dKgNApGhLU7q4WhRxszi/
+        hmTaYQc7FwfUfpX+2tX1TmFELXn3FhefXYuPpChSMQTe9D6GHcq4bDeNhzE8
+        xkVG8YNC2EpXT97vE0bLEByEykrt6vHcnRamxRnw0cmDoQUDQdZVlJ9mII6h
+        PZBdQ3DWaTlx8Ssyy/muD3LGrCagu5lRK4OG+gBlG3Rd6YyBlLkiQjEOjJQK
+        bG7KvDQZL/GGcywvd/ang7IGv46bKbwbZ+4WG3DrTTxEHjAz1nn012JpzIh7
+        s9ejZEnuZx4z0jaYuzVUY10e8o5hDZW9z8KwrHKWG5aKLBOZ5JzpkpU5MZQa
+        JVJSKDvPwvuBKKfLwX2ydBCu3YBg8vOndiqcHYFG/l0ODAw7qjK6pMWw/7AN
+        YTdDNlaTWrrMxZ30cdNyXaweuBxljzQN1A6Jd4sd7vbQTmbCWdubC6t1L5GX
+        EcAcOizetvqmu27j2i1WxUhbXLVVamWaZVIwoygvM1YaVSrsOWALbq3KZyWG
+        LWio1Z2tltU2KkH/AIJcmKPNkejaEssFVZywtOBa5TmzlIrMyKJ8AbR/cWHe
+        LB5hnS559jTU34H03uFRQLMTosyeB2KrpYCMGV4azYGD1FCkkmmaGmOJfAmI
+        L4NrwtD//x1lscPvCZSzZXYsymJZimNRpidEmT4PypRTpgDK1BDCTSZlSQG/
+        gqVpntGXQXn8jbyCejj1v5Auj0B6r3VqpF9HPX8YZ+Xemwfza6elr2wTtgfB
+        mGzEK8zuMo7QQ+L3y+abk2xmLc0IJZlMgac0VYIolUtOClHkRamfY5JN3jYb
+        v7hoRnZO82zy0/5pPtSeLy6cHd8e4uJ9I818rk3eNSFubvYj5wnGWzF+CC3L
+        /8l423dtV30eg6NjTeAb24/Xk9fzeqL626Hef1Thq67CofHu/xexMP1D8j2N
+        /4Dk1f5nI/n6DwAAAP//AwA1x+LmpxEAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:34 GMT
+- request:
+    method: get
+    uri: https://api.easypost.com/v2/shipments/shp_3fa366a52db149629db9b792ef84ffb7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - e6404687-81be-423f-b7ef-0b176045f365
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.056339'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web4sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xY3W/bNhD/Vww9pwZJkfrwW7BsDwVWBM22hw2FwI+jzVWm
+        BIpKmhb933eSLUdJusUFjGQBar+Ix7vj8X6/O5/8JdEBZARTyZisEkZo/oaI
+        N4T9xsiK81Wa/pmcJa6rAsQ++GRlZd3BWbKFrpNr6JLVXx9w1RhA6whdRO2m
+        ja7xuPUl0X0I4PUtbv5+dYF7tVRQVwZPTFa+r+uzZHiupLmWXqOMfD1LAlgY
+        rA4qXZSxR39J7z/65sajnxik/uj8utLj0Tu9vjVPXkXJqDeVM5PNbj2dMJft
+        rzgJdd/FZttVzttmktnQbDF2E1B1uO7gNpEmVFpoCjyjxDLGlchLxjKtpNY6
+        Z4XUZsiS+hv0EOj53v7sKCiOuaOX27uwm20r/e1dKgNApGhLU7q4WhRxszi/
+        hmTaYQc7FwfUfpX+2tX1TmFELXn3FhefXYuPpChSMQTe9D6GHcq4bDeNhzE8
+        xkVG8YNC2EpXT97vE0bLEByEykrt6vHcnRamxRnw0cmDoQUDQdZVlJ9mII6h
+        PZBdQ3DWaTlx8Ssyy/muD3LGrCagu5lRK4OG+gBlG3Rd6YyBlLkiQjEOjJQK
+        bG7KvDQZL/GGcywvd/ang7IGv46bKbwbZ+4WG3DrTTxEHjAz1nn012JpzIh7
+        s9ejZEnuZx4z0jaYuzVUY10e8o5hDZW9z8KwrHKWG5aKLBOZ5JzpkpU5MZQa
+        JVJSKDvPwvuBKKfLwX2ydBCu3YBg8vOndiqcHYFG/l0ODAw7qjK6pMWw/7AN
+        YTdDNlaTWrrMxZ30cdNyXaweuBxljzQN1A6Jd4sd7vbQTmbCWdubC6t1L5GX
+        EcAcOizetvqmu27j2i1WxUhbXLVVamWaZVIwoygvM1YaVSrsOWALbq3KZyWG
+        LWio1Z2tltU2KkH/AIJcmKPNkejaEssFVZywtOBa5TmzlIrMyKJ8AbR/cWHe
+        LB5hnS559jTU34H03uFRQLMTosyeB2KrpYCMGV4azYGD1FCkkmmaGmOJfAmI
+        L4NrwtD//x1lscPvCZSzZXYsymJZimNRpidEmT4PypRTpgDK1BDCTSZlSQG/
+        gqVpntGXQXn8jbyCejj1v5Auj0B6r3VqpF9HPX8YZ+Xemwfza6elr2wTtgfB
+        mGzEK8zuMo7QQ+L3y+abk2xmLc0IJZlMgac0VYIolUtOClHkRamfY5JN3jYb
+        v7hoRnZO82zy0/5pPtSeLy6cHd8e4uJ9I818rk3eNSFubvYj5wnGWzF+CC3L
+        /8l423dtV30eg6NjTeAb24/Xk9fzeqL626Hef1Thq67CofHu/xexMP1D8j2N
+        /4Dk1f5nI/n6DwAAAP//AwA1x+LmpxEAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:34 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Stock_Estimator/_shipping_rates/rates_are_found/shipping_methods_dont_exist/1_1_1_2_1.yml
+++ b/spec/cassettes/Spree_Stock_Estimator/_shipping_rates/rates_are_found/shipping_methods_dont_exist/1_1_1_2_1.yml
@@ -1,0 +1,306 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - a2b201d4-482c-4ff5-a511-d931032c412e
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_ae8eda75e16d43a8ba2014c76c7ee772"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.022426'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web3sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFf8XQnADyK3a8Bc0UoB36WLoYjETDLGTJkOX0
+        EeTfSzlBhi7VRF4ekhfUWZAWjQDtW8AaNVQlphtd5FAfIZNpoaqNqhCrKhMr
+        4Y4fqALzO609ThNLyiME1C1EmRuqtSzXMnvNZFMUTV6/MzOP+l/GwoBcPbje
+        JnuHcbIbRrDfLD7copWYgkcMaXSQ7Knr0KMNybMDfS9mXHxyPvSfOIU4hkKc
+        8Qj2RMbgwrGbSB04+aGRQ1nXebnsnG3wkX974XTsnY1kuTyZbrcs4gBkRGNn
+        Y1ZicDoC4bYLvCf0bQeKzLL3SvGtSLNTgntjhxo9mDbAVxu/4Kou1v5oJ/TU
+        kYJAzk6iOV8uvwAAAP//AwAYLuRGtQEAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:38 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 1dce8155-b588-41d5-9ba9-c6e3b35a510c
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_0164b0137b884836a428f1054e4e08bd"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.017571'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web15sj
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQMW/DIBCF/0rE3EhgYwd5y1qpXdIuXayzOStUGCx8ttpG
+        +e89EjlDlzJxj+/dPe4inBWNAJtaqWrdSVUeOmO0KWvQhRmUrDRqlKaz4knE
+        7hN7Yv5obcJ5ZqlPCIS2hSwXUh32strL4q2QjdZNaT6YWSb7LxNgRNGExXvu
+        GccJwvdWzpQQSbFXlWp32hk6744riu2lePgcsUm8QFid93eAB7P0+szFj5v4
+        Ko0pqxw8LoFS5t9PXE7nGPAWr9BVrfiwiCM4v3Ufo80A4UzZDik5TO0AvfO3
+        uXeK1+IsBnLwMA5oMYFvCb7avO3tVxztj7ZicoPrgVwMs2gu1+svAAAA//8D
+        ALhkVfagAQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:38 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10.0
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '19'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 8c0e4357-6572-4816-b38f-89c251d07217
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_b2c9d031d0a844c29f3df7149dcdbeaa"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.026972'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web4sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMOw7CMBBE77J1QGvHKJ9TUFDRRM7uJjGYxDKOKBB3x0h8
+        Ssp582bu4BhaCJF812tqGEvFaGtjSDdDyUOlTMPEvVgLBSz9SSjlwd5GEp8J
+        RbFJuLMvqlFVG9xtUB80tsa0ZX3Mzhr4r+NlHtME7bx6X8DN8S9M4sYpfVKI
+        wjK4Of8FS2c7ynf09hRusYDLwrmBJNcEjycAAAD//wMAwfqUEOcAAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:38 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[to_address][id]=adr_ae8eda75e16d43a8ba2014c76c7ee772&shipment[from_address][id]=adr_0164b0137b884836a428f1054e4e08bd&shipment[parcel][id]=prcl_b2c9d031d0a844c29f3df7149dcdbeaa
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '184'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 2a364ab4-e02f-4cbd-8290-ec076694f324
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_84f00e5d82f84844ac8c9d7598970101"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.206930'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web14sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xYUW/bNhD+K4aeU4OkSInyW7BsDwVWBM22hw2FQJFHm6tM
+        CRSVNC3y33eSLUdJusUFjHQB6ifxeHc83vfd6eQviQ6gIphSxWSVMELzN0S8
+        Iew3Rlacr1L5Z3KWuK4MEPvgk5VVdQdnyRa6Tq2hS1Z/fcBVYwCtI3QRtZs2
+        usbj1pdE9yGA17e4+fvVBe7VqoK6NHhisvJ9XZ8lw3OpzLXyGmXk7iwJYGGw
+        Oqh0UcUe/SW9/+ibG49+YlD6o/PrUo9H7/T61jx7lUpFvSmdmWx26+mEuWx/
+        xUmo+y4226503jaTzIZmi7GbgKrDdQe3iTKhJDTjFaFpXknJZZopzqSlRHDg
+        QGRlhixVf4MeAj3f258dBcUxd/Rqex92s22Vv71PZQCIFG1pShdXCxk3i/Nr
+        SKYddrBzcUDtV+WvXV3vFEbUkndvcfHZtfhIpEzFEHjT+xh2KOOy3TQexvAY
+        FxnFHwphq1w9eX9IGK1CcBBKq7Srx3N3WpgWZ8BHpw6GFgwEVZdRfZqBOIb2
+        SHYNwVmn1cTFO2SW810f1IxZTUB3M6NWBQ31Aco26LqsmC4MSakhSnKuWWFT
+        Y3PKC6NNBUrNsbzc2Z8Oyhr8Om6m8G6cuV9swK038RB5wMxY59Ffi6UxI+7N
+        Xo+SJXmYecxI22Du1lCOdXnIO4Y1VPY+C8OyxBtTnhU5t5ZzkRLJhKEyY8yk
+        LLM8m2fh/UCU0+XgIVk6CNduQDD5+VM7Fc6OQCP/LgcGhh1VGV1SOew/bkPY
+        zZCN5aSWLnNxL33atFwXy0cuR9kTTQO1Q+LdYoe7PbSTmXDW9ubCct0r5GUE
+        MIcOi7ctv+qu27h2i1Ux0hZXbSm5JQSEkcxit+FcaYmUzUUhi5xQQmclpvRY
+        qztbrcptrAT9AwhyYY620rlVGQWRihSJrqRlWVVVylqdE1GY74D2Ly7Mm8UT
+        rNPlSMJnoP4GpPcOjwKanRBl9jIQC6ltUWlGbYEFzaTMgPGUYZsrhE5R/eUh
+        vgyuCUP//3eUxQ6/Z1DOltmxKItlIY5FmZ4QZfpChayoJTm+qHIiuTai4FZb
+        ia6ElKyqiu+B8viOvIJ6OPW/kC6OQHqvdWqkX0c9fxhn5d6bR/Nrp5UvbRO2
+        B8GYbMQrzO4yjtBD4vfL5quTrAIJRuUCaGZ4qmSlEG6u80znAHnOXmKSTd42
+        G7+4aEZ2TvNs8tP+aT7Uni8unB2/HuLifaPMfK5N3jUhbm72I+cJxlsx/ggt
+        iv/JeNt3bVd+HoOjY03gF9uPz5PX83lS9bdDvf+owlddhUPj3f8vYmH6h+Rb
+        Gv8Byav9ayO5+wcAAP//AwAhXAtFpxEAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:38 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Stock_Estimator/_shipping_rates/rates_are_found/shipping_methods_exist/shipping_methods_are_not_front_end_visible/1_1_1_1_3_1.yml
+++ b/spec/cassettes/Spree_Stock_Estimator/_shipping_rates/rates_are_found/shipping_methods_exist/shipping_methods_are_not_front_end_visible/1_1_1_1_3_1.yml
@@ -1,0 +1,306 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 73a67a5b-bca7-455d-be77-1fb7a8dadd1d
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_154dce7c8cac49b58433b22a0b8613f9"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.018089'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web11sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFf8XQ7ADyK7G9Bc0UoB36WLoYtETBLGTJkOX0
+        EeTfKzlBhi7VRF4ekRfkmZFkLQPpuqwqpcCdqAWIsumruiyKPs+B9/U2K1TD
+        Umb7DxQ+8HspHc5zkIRD8Cg7iHLOs92GVxuev+a8Lcu22L4HZpnkv4yBEUP1
+        aAeTHCzGznacwHwH8eEWpWz2DtFn0UFyIKXQofHJswV5L+ah+GSdHz5x9rEN
+        +djjEcyJtMaVC24idQzJD00h5HVdVOvMxXgX+beXkE6DNZGs1sezJi4BRyDN
+        WrNonbLRygj42yxwjtB1CgTpde6VCrsiGZwS3D8qlOhAdx6+uniCq7pa+6Od
+        0JEiAZ6smVl7vlx+AQAA//8DAN45Ue+1AQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:36 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 745e56c8-a49e-455b-a53a-393e6a1d2b2d
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_617a1d87634c42b6b41f1c46f91b9e96"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.024521'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web15sj
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQP2/DIBDFv4rF3EgG479b1krtknbpYp3hrFBhsDC22kb5
+        7j0SOUOXMnGP37t73IUZzToGOvQVr4Hrpq4KqaQYqkHykStZjS0fWmwr9sT8
+        8IkqEn/UOuCykKQCQkTdQ5JFzutDXh5y8SbyTsquqD+IWWf9L+NgQta51Vrq
+        6acZ3PdeLjEgRk5eXvDslDXxnB03ZPuLePhMJBN7AbcZa+8ADSbp9ZmKHzPT
+        NW+aokzB/epiSPz7icr57B3e4glZVpwOiTiBsXv3yesERFxiskMIBkM/gjL2
+        NvdO0VqMRhcNPIwjagxg+whffdr2/iuK9kfbMJjRKIjGu4V1l+v1FwAA//8D
+        AHLn1dWgAQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:37 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10.0
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '19'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 19b89de3-9d9a-42cb-8cde-a0587a8d6365
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_c4bf62d32c784fd19ba0dfd11d1d9edd"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.052810'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web3sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMzQ6CMBCE32XPYNpSRfoUHjx5IWV3gWqBppZ4ML67NfHn
+        6GkyM9/MHRyBgRDRt6i7fqeoUljvdU+y6aygrJIkNUwEBSzdmTHlwcFGZJ8T
+        jGwTU2tfqRKyLsW2FOqohNHaVPUpM2ugv4zneUgjmHn1voCbo58Z2Q1j+rgQ
+        mbh3c/4LFi924O/ozUmxEQVMC+UGEl8TPJ4AAAD//wMAmCFPGucAAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:37 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[to_address][id]=adr_154dce7c8cac49b58433b22a0b8613f9&shipment[from_address][id]=adr_617a1d87634c42b6b41f1c46f91b9e96&shipment[parcel][id]=prcl_c4bf62d32c784fd19ba0dfd11d1d9edd
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '184'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - f0918404-2354-428b-aecd-87e305977048
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_9a8dfbfe52ea43dd86fb6c2dd1889e8b"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.214886'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web14sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xY3W/bNhD/Vww+u4YoUV9+C5btocCKoNn2sKEg+HG0ucqU
+        QFFJ3SL/+06y5ChJt7iA0SxA9WLyeHc83u/uePQXojyIAJqLQNYkjmj+Jkrf
+        RPFvcbRmbJ3kf5IlsS33EDrvyNqIqoUl2UHbig20ZP3XB5zVGlA6QBuQu26C
+        rR0ufSGq8x6c2uPi79eXuFYJCRXXuCNZu66qlqQfc6FvhFNIi+6WxIOBXurI
+        0gYROtRHOvfR1bcO9QQv1EfrNlwNWx/4ukY/exQpgtpyqyeZw3zaYU4bjzgR
+        VdeGetdy60w90Yyvd2i79sjaH7dXS4T2PKO5oLrIs4QpFstMMmqoYpkpqSyh
+        zHovyb9B9YZejPLLk6A45YxO7O7NrneNcPt7V3qAQFGWJnRxvSjCdnFxA2Ra
+        iY9yNvSo/Srcja2qA8OAGnn3FiefbYPDqCiStDe87lzwB5Rx2mxrB4N5MUsz
+        ih8SYSdsNWl/GDBKeG/BcyOUrYZ9D1zoFqvBBSuOggY0eFHxID7NQBxMe0S7
+        AW+NVWKKxTuMLOvazotZZNUe1c2EGuEVVEcoG68qrpg0WayTWOUFM5qWUkQa
+        f6mmugSt51heHeTPB2UFbhO2k3m3Vt9PtmA323C03KNnjHWor8HUmAXu7chH
+        o1X00PPokaZG322AD3l59Dua1Wf26IV+ymNQtFRxakqTsixKZJrkOTUALMoL
+        Lcu5F973gXI+HzwMlhb8je0RJD9/aqbEOQTQEH9XfQT6Q6jGdEWLfv1xGcJq
+        htHIJ7Zklaf31KdFy7aBP1I50J5waqgsBt4eK9z+WE5mxFnZmxP5phMYlwFA
+        HyssnpZ/VV27tc0Os2IIW5w1vBSFNtJAGoNgidZFZmSmYq1pUZRQyFmKCTXk
+        6kFWCb4LMqV/QISxMEc7STPNMkHLlBaoUUmsZ3EhVJQqKOL4JdD+xfp5sXiC
+        dbJi2fNQfwPSo8KTgI7PiHL8fSCWEnROI8iTSDKWsRIRNwUwrWihElAvAPGV
+        t7Xv6/+/o5we8HsG5WyVnYpyuirTU1GmZ0SZfh+UozJTeEvRPO9BpqmAlAnI
+        05gJk7AsfwmUhzvyGqp+1/9CujwB6ZHr3Ei/jnz+MPTKndOP+tdWCcdN7XdH
+        wuBsxMvPzjK00L3jx2n91U6WplgRIFeFEoqVMsXrIJFxLCJZZDQxD26CkzvZ
+        7IQYyu47WfK23rrFZT1E59TPkp/G0bypvVhcWjO8HsLifS30vK8l72oftrdj
+        y3mG9jYdvoiW5f+kve3apuWfB+PokBP4YvvxPHk9zxPZ7ft8/5GFrzoL+8I7
+        /i+Cz6Nx9C2F/4jk9XhtkLt/AAAA//8DAEcKp0enEQAA
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Stock_Package/_easypost_parcel/1_1_1.yml
+++ b/spec/cassettes/Spree_Stock_Package/_easypost_parcel/1_1_1.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10.0
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '19'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 05e1afba-1653-4005-a0f7-a6054f12de52
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_c7f8c01e29474f04bbd03427280bdf0e"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.026808'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web5sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMOw7CMBBE77J1gjbGyIlPQUFFE9neTWIwiWUcUSDujpH4
+        lJTz5s3cwRNoiMmF3qmhddiw6KSSA0prCbdSKNGipQEZKljsiV0ug71JjkMh
+        LrHJTL15UYGNqnFXozgI1FJq0R2Ls0b66wSexzyBntcQKrh5+oWJ/TjlT4qJ
+        iQc/l79o3NmM/B29vQY3WMFlodJA5muGxxMAAP//AwDeXV/F5wAAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Spree_Stock_Package/_easypost_shipment/1_2_1.yml
+++ b/spec/cassettes/Spree_Stock_Package/_easypost_shipment/1_2_1.yml
@@ -1,0 +1,306 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '222'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 49e52df6-0960-43f2-b3e7-514935d8da74
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_7c20295b3c6c40818854501231705958"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.029506'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web6sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFfyXQnACybDW2t6KZArRDH0sXg5FohIUsGbKS
+        PoL8eyknyNClmsjLo8sL6STIilaAjd3aKKkavSvNnalkXdS1rrQsVFmspW50
+        LZYi7D7QJObvrY04TSyZiJDQdpBlJYv1SuqVVK9KtlXVlvKdmcNo/2U8DMjT
+        bdj7xSZgdg7DCP6bxYdrtRRTioipyAkWG+p7jOjT4jmAvQ0VD59CTPtPnFK2
+        oZQ9HsEfyTmcOU6TqS03PzRyKeu61PPOg08x828v3I774DOp5yOLpmERByAn
+        Wn9wbimGYDOQrrsgRsLY9WDIzXsvFL8VWU5KcLvYo8UIrkvw1eUvuKhztD/a
+        ESP1ZCBR8JNoT+fzLwAAAP//AwBHdpA+tQEAAA==
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:30 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '148'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 8b64d9eb-8d73-4866-b460-589bbca8b08b
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_c42858cad74f4743bec1873afa4accd2"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.025142'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web15sj
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQMW/DIBCF/4rF3EiAcY28Za3ULmmXLtYFzgoRBgtjq22U
+        /94jkTN0KRP3+N7d4y7MWdYxsKk3SupGG7CtGlSr6iMaodsaBlBgjJXsicXj
+        GU0mfm9twnkmySSEjLaHIksu2h1vdly+S94p1dX8k5hlsv8yAUZkXVi8p55x
+        nCB8b+WcE2IW5BW1qA6VzqdqvyLbXuTD5zKZ2CuE1Xl/B2gwSW8vVPy4ia5c
+        67opweMScir8x4HK6RQD3uJJ1TwLOiTiCM5v3cdoC5BxzsUOKTlM/QDG+dvc
+        O0VrcRZDdvAwDmgxge8zfPVl29uvKNofbcXkBmcguxhm1l2u118AAAD//wMA
+        cghkeaABAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:30 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: parcel[weight]=10.0
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '19'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 653fd6ac-c727-4a77-b04c-c783dcaa3b8d
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_1082bd68de734eaf8ce1039c35330767"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.017239'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web14sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb4sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMvRKCMBCE3+VqdI4ECOYpLKxsmJA7IBohE8NYOL67ccaf
+        0nK//Xbv4Ag0hGh9V2IrempaYiUrNkNruUS5s7KWElWjoIClP7FNebA30bLP
+        xEY2iakzLyqwVBusNygOAnVVaYnH7KyB/jqe5zFNoOfV+wJujn5hYjdO6ZNC
+        ZOLBzfkvGHs2I39Hb6/ELRZwWSg3kPia4PEEAAD//wMAFxMRCecAAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:30 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: shipment[to_address][id]=adr_7c20295b3c6c40818854501231705958&shipment[from_address][id]=adr_c42858cad74f4743bec1873afa4accd2&shipment[parcel][id]=prcl_1082bd68de734eaf8ce1039c35330767
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - EasyPost/v2 RubyClient/2.7.0
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '184'
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - a3791fe7-ae65-4d9d-b3ec-89652f63b83d
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_b32fedd063af4986b137e1444534fdf2"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.197568'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - 0c5331f72e
+      - easypost
+      - web11sj
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - lb5sj, 8657dcde98
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xYS2/cNhD+KwudHYNPidqbUbeHAA2MuO2hRSDwpV02Wkqg
+        KDtO4P/ekVaStXYSr1E3qYHsSRzODIfzfTM70qdEByujNYWMyTohCGevEH+F
+        yG8ErRlbU/RncpK4tgg2dsEn61JWrT1JdrZt5ca2yfqvd7CqjQXraNsI2nUT
+        Xe1h61OiuxCs1zew+fvlOexVUtmqMHBisvZdVZ0k/XMhzZX0GmTo9iQJtrS9
+        1azSRhk78Jd0/r2vrz34iUHq985vCj0cvdfrGvPoVZSMels4M9ns19MJS9l4
+        xUmouzbWu7ZwvqwnWRnqHcRuAqj21+3dJtKEQjMiuNDSZKxkGaPKaiwyKkvJ
+        pNaG9FlSf1vdB3o22p8cBcUxd/Rydxd2vWukv7lLZbA2YrDFFK8uVyJuV2dX
+        Npl2yGznYo/ar9JfuaraKwyoJW9ew+Kja+ARCUF5H3jd+Rj2KMOy2dbeDuER
+        xlMMPxDanXTV5P2QMFqG4GwoSqldNZy714K0OGN9dHI2LK2xQVZFlB8WIA6h
+        3ZNd2eBKp+XExVtglvNtF+SCWXUAdwujRgZtqxnKJuiqwEgQZVJhbEaZlaXQ
+        FiOaa8opRVmaLbG82Ns/H5SV9Zu4ncK7duZusbVus41z5AEyUzoP/hoojQVx
+        r0c9jE7RYeYhI00NudvYYqjLOe8QVl/ZYxbCUKE8U1YpkeUpZZQpwXNVZlmG
+        qGJcDQjPWXjbE+X5cnBIltaGK9cjmPziwpI+A/suev6FPVHpKUv77fs9CFoZ
+        ULGYtTJ+J3zYsFwbi0OHg+iBorGVA87dQHO7geSRA8mi3S2FxaaTwMdorZk7
+        K9yyeOir3bpmB6UwcBVWTaEogWIwKIWuwnKRKkwzixljnLLSlGRRV9By+gLd
+        22pZ7KLi+A+LgABLiClnOdZIUs05K4kSJTHgLssJ4UII8h0gvgiuDn1H+DLK
+        fI/fIyinp+mxKPPTnB+LMn5GlPG3QTlLNTJM5koZzEiOhEI45ZKnNoeDpP0e
+        KA9d89JW/alfQzo/AulR67mRfoH1LFMscJZDd9aKEWRzAt3aaCowKmkq1NOR
+        xkcgjb+G9M8fmmnW+QLIBJ9i8TjK5Alte3J5FM6fQfXfQD3OJ/8N2u+GWbnz
+        5t782mrpi7IOu1kwlBZgFhbXGUboHoFxWX92ks00THHAIapTzZDAQnDGESYU
+        Z4jnXHyLSTZ5XW/96rweGDrNs8lP49NyqD1bnbtyeHuIq7e1NMu5NnlTh7i9
+        HkfOZxhv+fBDOM//J+Nt1zZt8XEIDg+lAW9sP15PXs7riepu+nr/UYUvugr7
+        xjt+Fynt9IXkKY1/RvJy/NtIbv8BAAD//wMAzwFkTKcRAAA=
+    http_version: 
+  recorded_at: Tue, 02 May 2017 20:44:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/decorators/shipment_decorator_spec.rb
+++ b/spec/decorators/shipment_decorator_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Spree::Shipment, :vcr do
   let(:shipment) do
-    create :shipment do |shipment|
-      shipment.update address: create(:address)
-    end
+    create :shipment
   end
 
   describe '#easypost_shipment' do

--- a/spec/easypost/stock_estimator_decorator_spec.rb
+++ b/spec/easypost/stock_estimator_decorator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Stock::Estimator, :vcr do
-  let(:estimator) { described_class.new shipment.order }
+  let(:estimator) { described_class.new }
   let!(:shipment) { create :shipment }
   let(:package) { shipment.to_package }
 

--- a/spec/easypost/stock_estimator_decorator_spec.rb
+++ b/spec/easypost/stock_estimator_decorator_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Stock::Estimator, :vcr do
-  let(:estimator) { described_class.new }
+  if Spree.solidus_gem_version < Gem::Version.new("1.3")
+    let(:estimator) { described_class.new(shipment.order) }
+  else
+    let(:estimator) { described_class.new }
+  end
+
   let!(:shipment) { create :shipment }
   let(:package) { shipment.to_package }
 

--- a/spec/easypost/stock_estimator_decorator_spec.rb
+++ b/spec/easypost/stock_estimator_decorator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Stock::Estimator, :vcr do
-  if Spree.solidus_gem_version < Gem::Version.new("1.3")
+  if SolidusSupport.solidus_gem_version < Gem::Version.new("1.3")
     let(:estimator) { described_class.new(shipment.order) }
   else
     let(:estimator) { described_class.new }

--- a/spec/easypost/stock_estimator_decorator_spec.rb
+++ b/spec/easypost/stock_estimator_decorator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Spree::Stock::Estimator, :vcr do
         end
 
         context 'shipping methods are not front end visible' do
-          before { Spree::ShippingMethod.update_all display_on: :back_end }
+          before { Spree::ShippingMethod.all.each{|x| x.update!(display_on: 'back_end') } }
           it { is_expected.to be_empty }
         end
       end


### PR DESCRIPTION
This drops support for Solidus 1.0, in exchange for supporting versions up to master :tada:

This also starts along the path of having a `SolidusEasypost::Estimator`, instead of overriding the `Spree::Estimator`