### PR TITLE
Spec suite maintenance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,7 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 gem 'solidus_auth_devise'
 
-if branch == 'master' || branch >= "v2.3"
-  gem 'rails', '~> 5.1.0' # hack for broken bundler dependency resolution
-elsif branch >= "v2.0"
-  gem 'rails', '~> 5.0.0' # hack for broken bundler dependency resolution
-else
-  gem "rails", '~> 4.2.0' # hack for broken bundler dependency resolution
-end
+gem 'rails', '~> 5.1', '>= 5.1.6'
 
 if branch < 'v2.5'
   gem 'factory_bot', '4.10.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,8 @@
 source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem 'solidus', github: 'solidusio/solidus', branch: branch
+gem 'solidus', git: 'https://github.com/solidusio/solidus.git', branch: branch
 gem 'solidus_auth_devise'
-
-gem 'rails', '~> 5.1', '>= 5.1.6'
 
 if branch < 'v2.5'
   gem 'factory_bot', '4.10.0'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,12 @@ else
   gem "rails", '~> 4.2.0' # hack for broken bundler dependency resolution
 end
 
+if branch < 'v2.5'
+  gem 'factory_bot', '4.10.0'
+else
+  gem 'factory_bot', '> 4.10.0'
+end
+
 gem 'pg'
 gem 'mysql2'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,10 @@ else
   gem 'factory_bot', '> 4.10.0'
 end
 
-gem 'pg'
-gem 'mysql2'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
 
 gemspec

--- a/app/models/solidus_easypost/estimator.rb
+++ b/app/models/solidus_easypost/estimator.rb
@@ -16,7 +16,7 @@ module SolidusEasypost
             shipping_method: find_or_create_shipping_method(rate)
           )
 
-          shipping_rates << spree_rate if spree_rate.shipping_method.frontend?
+          shipping_rates << spree_rate if spree_rate.shipping_method.available_to_users?
         end
 
         # Sets cheapest rate to be selected by default
@@ -39,7 +39,7 @@ module SolidusEasypost
       method_name = "#{ rate.carrier } #{ rate.service }"
       Spree::ShippingMethod.find_or_create_by(admin_name: method_name) do |r|
         r.name = method_name
-        r.display_on = 'back_end'
+        r.available_to_users = false
         r.code = rate.service
         r.calculator = Spree::Calculator::Shipping::FlatRate.create
         r.shipping_categories = [Spree::ShippingCategory.first]

--- a/lib/spree_easypost/factories.rb
+++ b/lib/spree_easypost/factories.rb
@@ -1,11 +1,11 @@
-FactoryGirl.define do
+FactoryBot.define do
   # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
   #
   # Example adding this to your spec_helper will load these Factories for use:
   # require 'spree_easypost/factories'
 end
 
-FactoryGirl.modify do
+FactoryBot.modify do
   factory :address do
     lastname "Doe"
   end

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus', ['>= 1.1', '< 3.x']
   s.add_dependency 'solidus_support', '>= 0.1.1'
   s.add_dependency 'easypost'
+  s.add_dependency "deface", '~> 1.0'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl', '~> 4.4'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sass-rails'

--- a/spec/cassettes/Spree_EasyPost_ReturnAuthorization/_return_label/1_2_1.yml
+++ b/spec/cassettes/Spree_EasyPost_ReturnAuthorization/_return_label/1_2_1.yml
@@ -5,78 +5,6 @@ http_interactions:
     uri: https://api.easypost.com/v2/addresses
     body:
       encoding: UTF-8
-      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
-      Authorization:
-      - Bearer CvzYtuda6KRI9JjG7SAHbA
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Content-Length:
-      - '222'
-      Host:
-      - api.easypost.com
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Ep-Request-Uuid:
-      - b51621a9-e893-44ad-ac08-c4047adafcd8
-      Cache-Control:
-      - no-cache, no-store, must-revalidate, private
-      Pragma:
-      - no-cache
-      Expires:
-      - '0'
-      Location:
-      - "/api/v2/addresses/adr_379981d205194a6b84e11e4f6ccf4ba1"
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Runtime:
-      - '0.018418'
-      Content-Encoding:
-      - gzip
-      Transfer-Encoding:
-      - chunked
-      X-Node:
-      - 0c5331f72e
-      - easypost
-      - web4sj
-      X-Backend:
-      - easypost
-      X-Proxied:
-      - lb5sj, 8657dcde98
-      Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4SRPW/CMBCG/wryDJIdHEiyoTIhtUM/li7REZ/FVY4dOYZ+
-        IP57zwExdKmnu/cev/fKPgsyohFgYrtc13WlTCFLVWtY7SuNSqG2q66zeg9K
-        zEXYf2CXmN8YE3EcWeoiQkLTQpYLqdYLWS5k8VrIRutGF+/MHAfzL+OhR57u
-        wsHPtgGzc+gH8N8sPtyquRhTREwqJ5htyVqM6NPsOYC5DwsePoWYDp84pmxD
-        KXs8gj+RczhxnCZTO25+aOBSVtWynHYefYqZf3vhdjgEn8lyOlLVNYvYAznR
-        +KNzc9EHk4F02wUxEsbWQkdu2nul+K3IcFKC+0WLBiO4NsFXm7/gqk7R/mgn
-        jGSpg0TBj6I5Xy6/AAAA//8DAC2bZYm1AQAA
-    http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:42 GMT
-- request:
-    method: post
-    uri: https://api.easypost.com/v2/addresses
-    body:
-      encoding: UTF-8
       string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
     headers:
       Accept:
@@ -84,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
@@ -105,7 +33,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ep-Request-Uuid:
-      - c5b15bd9-1ea7-4de8-bebd-8fd5fdd929bb
+      - 599d2062-ae6b-4f82-9c48-59849a50181c
       Cache-Control:
       - no-cache, no-store, must-revalidate, private
       Pragma:
@@ -113,266 +41,32 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/addresses/adr_bc98fb84c8da466b9676106135e80fe4"
+      - "/api/v2/addresses/adr_4f7d7aec41a8437a869316d2ee8228c1"
       Content-Type:
       - application/json; charset=utf-8
       X-Runtime:
-      - '0.022951'
+      - '0.037471'
       Content-Encoding:
       - gzip
       Transfer-Encoding:
       - chunked
       X-Node:
-      - 0c5331f72e
-      - easypost
-      - web11sj
+      - bigweb4sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb4sj, 8657dcde98
+      - extlb2sj 130594cc1d
+      - intlb1sj 130594cc1d
       Strict-Transport-Security:
       - max-age=15768000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4SQMW/DIBCF/4rF3EiAsUO8Za3ULmmXLtYZzgoVxhbGVtso
-        /71HImfoUibu8b27x12Ys6xhYGPbmYPuO62MtqDqujvU+1rwWpQVat6jYk9s
-        7D7RJOKP1kacZ5JMREhoW8iy5GK/49WOyzfJG6UaJT+IWSb7LxNgQNaExXvq
-        OQ4ThO+tnFNETIK8ohTFqdDpXBxXZNuLfPhcIhN7gbA67+8ADSbp9ZmKHzfR
-        lWtdVjn4uIQUM/9+onI6jwFv8aSqakGHRBzA+a37MNoMJJxTtkOMDmPbg3H+
-        NvdO0VqcxZAcPIw9Wozg2wRfbd729iuK9kdbMbreGUhuDDNrLtfrLwAAAP//
-        AwAWqSEvoAEAAA==
+        H4sIAAAAAAAAA4SQP0/DMBDFv0rkmUo955/J1hUJlsLCEh32RTVy7MhxIqDqd+fcKh1Y8OR7/r275zsLa0Qn0MS+GlrTIukKUFVli6p5LKExkkhJqTSIBxE+Pkkn5g/GRJpnlnQkTGR6zLLcg9qB3IF6hbor266Gd2aWyfzLeBxJdH5xjnuGcUL/vZVzikQJ2AslFMdCpVNxWElsL/Lus4lN4hn9ap27ATyYpZcnLn7sxNe9UmWdg4fFp5j5tyOX0yl4usaTVd0AHxZpROu27mMwGUg0p2zHGC3FfkBt3XXujeK1WEM+WbwbBzIU0fUJv/q87e1XHO2PtlK0g9WYbPCz6M6Xyy8AAAD//wMA0xAKXKABAAA=
     http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:42 GMT
-- request:
-    method: post
-    uri: https://api.easypost.com/v2/parcels
-    body:
-      encoding: UTF-8
-      string: parcel[weight]=10.0
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
-      Authorization:
-      - Bearer CvzYtuda6KRI9JjG7SAHbA
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Content-Length:
-      - '19'
-      Host:
-      - api.easypost.com
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Ep-Request-Uuid:
-      - 4cfebb72-9c95-4e5e-b44a-61304f0c98be
-      Cache-Control:
-      - no-cache, no-store, must-revalidate, private
-      Pragma:
-      - no-cache
-      Expires:
-      - '0'
-      Location:
-      - "/api/v2/parcels/prcl_f59417e6c55845668c6c5601c8e031af"
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Runtime:
-      - '0.015229'
-      Content-Encoding:
-      - gzip
-      Transfer-Encoding:
-      - chunked
-      X-Node:
-      - 0c5331f72e
-      - easypost
-      - web14sj
-      X-Backend:
-      - easypost
-      X-Proxied:
-      - lb5sj, 8657dcde98
-      Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4SMOw7CMBBE77J1QOtgO8GnoKCiicx6kxhMYhlHFIi7YyQ+
-        Jd183swdvAMDMVHoerWVomFNSrVSad1SkRoFtYwbYXuoYD6emHIZ7GwiDiWh
-        xDaz6+wrrVE0K1QrrPc1GimNrA+FWaL7ywSehjyCmZYQKrh59zMj+2HMHxcT
-        O+79VP6ipbMd+Dt6cwLXWMFldqWBzNcMjycAAAD//wMAvDDtZ+cAAAA=
-    http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:42 GMT
-- request:
-    method: post
-    uri: https://api.easypost.com/v2/shipments
-    body:
-      encoding: UTF-8
-      string: shipment[to_address][id]=adr_379981d205194a6b84e11e4f6ccf4ba1&shipment[from_address][id]=adr_bc98fb84c8da466b9676106135e80fe4&shipment[parcel][id]=prcl_f59417e6c55845668c6c5601c8e031af
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
-      Authorization:
-      - Bearer CvzYtuda6KRI9JjG7SAHbA
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Content-Length:
-      - '184'
-      Host:
-      - api.easypost.com
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Ep-Request-Uuid:
-      - a32be5ae-4da3-40b4-adbc-c3f878e5d3cd
-      Cache-Control:
-      - no-cache, no-store, must-revalidate, private
-      Pragma:
-      - no-cache
-      Expires:
-      - '0'
-      Location:
-      - "/api/v2/shipments/shp_8b3d8a0bcbff4a64972a63e02b83f4cf"
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Runtime:
-      - '0.205830'
-      Content-Encoding:
-      - gzip
-      Transfer-Encoding:
-      - chunked
-      X-Node:
-      - 0c5331f72e
-      - easypost
-      - web3sj
-      X-Backend:
-      - easypost
-      X-Proxied:
-      - lb4sj, 8657dcde98
-      Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA+xYUW/bNhD+K4aeU4OkKJr0W7BsDwVWBM22hxWFQFFHm6tM
-        CRSVNC3y33eSJUdJusUFvGYF6ifxeHc83vfd6eTPiQmgI5S5jsk6YYSuXpHs
-        FWG/MbLmfM3Zn8lZ4to8QOyCT9ZWVy2cJTtoW72BNlm/e4+rugS0jtBG1K6b
-        6GqPW58T04UA3tzi5u9XF7hX6QKqvMQTk7Xvquos6Z9zXV5rb1BG7s6SABZ6
-        q4NKG3Xs0F/S+Q++vvHoJwZtPji/yc1w9F6va8pnr1LoaLa5Kyeb/Xo6YS4b
-        rzgJTdfGetfmztt6ktlQ7zD2MqBqf93ebaLLkBdGSVtIbmSpuRCFEitBiaBp
-        BpJY4H2Wir/A9IGej/ZnR0FxzB293t2HXe8a7W/vUxkAIkVbmtLF1ULG7eL8
-        GpJphx3sXOxR+1X7a1dVe4UBteTNa1x8cg0+EinTrA+87nwMe5Rx2WxrD0N4
-        jGeC4g+FsNOumrw/JIzRITgIudXGVcO5ey1MiyvBR6cPhhZKCLrKo/44A3EI
-        7ZHsGoKzzuiJi3fILOfbLugZs+qA7mZGjQ4GqgOUTTBVbjPF6QqEyTKJ1xHS
-        4KMg1EggKdV2juXl3v50UFbgN3E7hXfjyvvFFtxmGw+RB8yMdR79NVgaM+Le
-        jHqULMnDzGNGmhpzt4F8qMtD3jGsvrLHLPTLnMHKWG01Y1LwlREKOW0V8twU
-        HCSn8yy87Ylyuhw8JEsL4dr1CCY/f2ymwtkTaODfZc/AsKcqo0sq+/3HbQi7
-        GbIxn9TS5Sq7lz5tWq6N+SOXg+yJZgmVQ+LdYoe7PbSTmXDW9ubCfNNp5GUE
-        KA8dFm+bf9Fdu3XNDqtioC2umlwWaSk1KUxhLdeCqxXTIgXCCplabuysxLQZ
-        anVva3S+i0VG/wCCXJijnVIFiisqjaK8BFCGKCkKueJGEC7sC6D9iwvzZvEE
-        63TJxfNQfwXSo8OjgGYnRJl9G4gN9jRJmVVcSA6ZlVlKLKNCiIyXKpUvAPFl
-        cHXo+/8/o5zt8XsGZbEUx6KcLVV2LMr0hCjTb4Myo0SbgkDGmOBZQaVQElYZ
-        ADUlvrzZS6A8vCOvoOpP/Tek1RFIj1qnRvr7qOf3w6zc+fLR/Noa7XNbh91B
-        MCQb8QqzuwwjdJ/4cVl/cZJNV0pJWjKSUYWB4kwLlAK3whjLC/3gvf9fTbLJ
-        63rrFxf1wM5pnk1+Gp/mQ+354sLZ4eshLt7WupzPtcmbOsTtzThynmC8zYYf
-        oUr9T8bbrm3a/NMQHB1qAr/YfnyefD+fJ0V329f7jyr8rquwb7zj/yIWpn9I
-        vqbxH5C8Gl8byd3fAAAA//8DACLV1Y6nEQAA
-    http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:42 GMT
-- request:
-    method: post
-    uri: https://api.easypost.com/v2/addresses
-    body:
-      encoding: UTF-8
-      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
-      Authorization:
-      - Bearer CvzYtuda6KRI9JjG7SAHbA
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Content-Length:
-      - '148'
-      Host:
-      - api.easypost.com
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Ep-Request-Uuid:
-      - b750fa63-ad5e-41c4-ba3f-e7ada38140e0
-      Cache-Control:
-      - no-cache, no-store, must-revalidate, private
-      Pragma:
-      - no-cache
-      Expires:
-      - '0'
-      Location:
-      - "/api/v2/addresses/adr_0ce6bd768fb5475e9652d2db0acfc5ea"
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Runtime:
-      - '0.015773'
-      Content-Encoding:
-      - gzip
-      Transfer-Encoding:
-      - chunked
-      X-Node:
-      - 0c5331f72e
-      - easypost
-      - web11sj
-      X-Backend:
-      - easypost
-      X-Proxied:
-      - lb5sj, 8657dcde98
-      Strict-Transport-Security:
-      - max-age=15768000; includeSubDomains; preload
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA4SQMW+DMBCF/0rkuZGMwUDZslZql7RLF3T4DsWRsZExqG2U
-        /94jERm61JPv+Xt3z3cRFkUjAGMrDZUdVmXdd7qoND2XWqHCToLpjSYQTyJ0
-        ZzKJ+QNipGliyUSCRNjCKiuZVXup91K9K9kURVPkn8zMI/7LeBhINH52jnuG
-        YQT/vZVTikQpY2+WZ7vjrk6n3WEhsb2oh88mNolX8It17g7wYJbeXrj4sSNf
-        ZV3neg0eZp/iyn8cuRxPwdMtnip0mfFhkQawbus+BFyBRFNa7RCjpdj2YKy7
-        zb1TvBaL5JOFh7EnpAiuTfDVrtvefsXR/mgLRdtbA8kGP4nmcr3+AgAA//8D
-        ADYK2JqgAQAA
-    http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:43 GMT
+  recorded_at: Tue, 18 Dec 2018 15:37:51 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/addresses
@@ -385,7 +79,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
@@ -406,7 +100,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ep-Request-Uuid:
-      - 615b5d91-f6af-4787-820e-b36a56f6b44f
+      - f342b0ff-2c3b-4062-ad4b-8e9b7fc5b641
       Cache-Control:
       - no-cache, no-store, must-revalidate, private
       Pragma:
@@ -414,39 +108,33 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/addresses/adr_d7f4bd1678954c2f9e66b263e1984a0e"
+      - "/api/v2/addresses/adr_72680faba1c6458692cb1d3b7f983580"
       Content-Type:
       - application/json; charset=utf-8
       X-Runtime:
-      - '0.023790'
+      - '0.036450'
       Content-Encoding:
       - gzip
       Transfer-Encoding:
       - chunked
       X-Node:
-      - 0c5331f72e
-      - easypost
-      - web15sj
+      - bigweb9sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
-      X-Canary:
-      - direct
       X-Proxied:
-      - lb4sj, 8657dcde98
+      - extlb1wdc 130594cc1d
+      - intlb1wdc 130594cc1d
+      - intlb2sj 130594cc1d
       Strict-Transport-Security:
       - max-age=15768000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4SRu27DMAxFfyXQnACy4/cWNFOAduhj6WLQFgWzkCVDVtJH
-        kH8v5QQZulQTeXnEeyGdBSnRCFC+VaXOOpUUZVXnWZ/qGouiS4stJnWVgUSx
-        Fq77wD4wv1PK4zyz1HuEgKqFKKcyKTcy38j0NZVNljXZ9p2Z46T+ZSyMyNOD
-        G+xq76JZ78YJ7DeLD7dqLebgEUMSE6z2pDV6tGH17EDdhykPn5wPwyfOIa6h
-        EHc8gj2RMbhwnCZSB25+aOJSVtU2XzyPNvjIv71wOw3ORjJfjkzqmkUcgYxo
-        7NGYtRidikC4eYH3hL7V0JNZfK8UvxUpTkpwv6hRoQfTBvhq4xdc1SXaH+2E
-        njT1EMjZWTTny+UXAAD//wMAS+WterUBAAA=
+        H4sIAAAAAAAAA4SRu27DMAxFfyXQnACWU9uyt6KZArRDH0sXg7YomIUsGbKSPoL8eyknyNClmsjLI/JSOgnSohGgQ1vlpcoMdCD78q5QZZ33ndTbrjK12hYqE2vhuw/sI/P3WgecZ5b6gBBRt5DkPJNqI/ONVK+yaLZVU+TvzBwm/S/jYESu7v3gVjuPqbMfJ3DfLD5co7WYY0CMMjlY7cgYDOji6tmDvhVzLj75EIdPnGNqQzH1eAR3JGtx4dhNovac/NDEYaZ4xWXmwcWQ+LcXTqfBu0QWy8lkXbOII5AVjTtYuxaj1wmI11kQAmFoDfRkl7kXit+KNDsluF00qDGAbSN8tekLLupi7Y92xECGeojk3Sya0/n8CwAA//8DADB4O3i1AQAA
     http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:43 GMT
+  recorded_at: Tue, 18 Dec 2018 15:37:52 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/parcels
@@ -459,7 +147,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
@@ -480,7 +168,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ep-Request-Uuid:
-      - 956bdbb2-66e8-4075-8cca-72af19c57cec
+      - d20c091d-efc8-4321-90dd-5c6edc0cbb12
       Cache-Control:
       - no-cache, no-store, must-revalidate, private
       Pragma:
@@ -488,47 +176,45 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/parcels/prcl_2d1af804fe9e49b090e775db7c8d2551"
+      - "/api/v2/parcels/prcl_cfba46ea83794c518f67e4ae62c1da46"
       Content-Type:
       - application/json; charset=utf-8
       X-Runtime:
-      - '0.013684'
+      - '0.036955'
       Content-Encoding:
       - gzip
       Transfer-Encoding:
       - chunked
       X-Node:
-      - 0c5331f72e
-      - easypost
-      - web4sj
+      - bigweb6sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb5sj, 8657dcde98
+      - extlb2sj 130594cc1d
+      - intlb2sj 130594cc1d
       Strict-Transport-Security:
       - max-age=15768000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4SMOw7CMBBE77J1QGtjy0lOQUFFEzneTWIwiWUcUSDujpH4
-        lJTz5s3cwRO0EJMLnSRhhxrVwA2rpscG2RhNvXE1Sa0FVLD0J3a5DPY2OQ6F
-        uMQ2M3X2RSUKs0G9QXmQ2CrVqt2xOGukv07gecwTtPMaQgU3T78wsR+n/Ekx
-        MfHg5/IXrTvbkb+jtydwixVcFioNZL5meDwBAAD//wMATV683ucAAAA=
+        H4sIAAAAAAAAA4SMOw7CMBBE77J1QHG+xqegoKKJNrubxGASyziiQNwdI/EpKefNm7mDZTDgA7mOhh6rRlCX7a6iWumhaaVCaQpSnBrIYOlPQjEN9hhIXCIUBKNwhy9a5EpvVLFR+qBqU7amLo/JWT3/dZzMY5zAzKtzGdws/8IkdpziJ/kgLIOd059HOuMo39HbU/k2z+CycGogyjXC4wkAAP//AwBKjq+b5wAAAA==
     http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:43 GMT
+  recorded_at: Tue, 18 Dec 2018 15:37:53 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/shipments
     body:
       encoding: UTF-8
-      string: shipment[from_address][id]=adr_0ce6bd768fb5475e9652d2db0acfc5ea&shipment[to_address][id]=adr_d7f4bd1678954c2f9e66b263e1984a0e&shipment[parcel][id]=prcl_2d1af804fe9e49b090e775db7c8d2551&shipment[is_return]=true
+      string: shipment[from_address][id]=adr_4f7d7aec41a8437a869316d2ee8228c1&shipment[to_address][id]=adr_72680faba1c6458692cb1d3b7f983580&shipment[parcel][id]=prcl_cfba46ea83794c518f67e4ae62c1da46&shipment[is_return]=true
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
@@ -549,7 +235,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ep-Request-Uuid:
-      - cdbf20cc-87e3-4386-a3fe-d09b4abfc799
+      - ad8047e3-c063-4fba-b688-e71c78721d17
       Cache-Control:
       - no-cache, no-store, must-revalidate, private
       Pragma:
@@ -557,66 +243,46 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_76daef2727dd420798f2e3ad35ca64a3"
+      - "/api/v2/shipments/shp_eafc9b0c78314785a673a953cc5fc690"
       Content-Type:
       - application/json; charset=utf-8
       X-Runtime:
-      - '0.193512'
+      - '0.435523'
       Content-Encoding:
       - gzip
       Transfer-Encoding:
       - chunked
       X-Node:
-      - 0c5331f72e
-      - easypost
-      - web11sj
+      - bigweb6sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb4sj, 8657dcde98
+      - extlb2wdc 130594cc1d
+      - intlb1sj 130594cc1d
+      - intlb1wdc 130594cc1d
       Strict-Transport-Security:
       - max-age=15768000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+xY32/cNgz+Vw5+Tg+yLPnHvQXL9lBgRdBse1hRGJRE32n1
-        yYYsJ02L/O+jfeeLk3TNFUibBeg9WRRJUfw+0vR9jrRHCGhKCNEq4izOXjH5
-        ivE/OFsJsRLJ39FJZLvSY+i9i1bB93gSbbHrYI1dtHr3nlaNQTIO2AVSbtpg
-        G0dbnyPde49OX9PmnxdntFeDwro0dGC0cn1dn0TDcwnmEpwmGbs5iTxWOFgd
-        VLoAoSd/Ue8+uObKkZ/gQX+wbl3q8eidXt+aR2+iIOhNac1ks1tPJ8xl+ytO
-        Qt13odl2pXVVM8kq32wpduNJdbju4DYC40umMVUmS/NKSZFJLFLJDTeKga60
-        RBiypP5BPQR6urc/OQqJY+7oYHsbdrNtwV3fptIjhphs4yReXCzysFmcXmI0
-        7fCDnQ0Dar+Du7R1vVMYUYvevKbFJ9vSI8vzRA6BN70LfocyLdtN43AMjwuZ
-        xvQjIW7B1pP3u4TR4L1FX1agbT2eu9OitFiDLlg4GFZo0ENdBvg4A3EM7Z7s
-        Er2trIaJizfELOu63sOMWY0ndzOjFrzG+gBl63VdchNDlTNRYYGiUKxgmGXS
-        qEznhksZz7E839k/HZQ1unXYTOFdWXO72KBdb8Ihck+Zqawjfy2Vxoy4V3u9
-        mC3Z3cxTRtqGcrfGcqzLQ94prKGy91kYlqXgRWxQxlDkUjAZF6YqEDApQGqS
-        4DwLbweiPJoDcUQORp27ZOnQX9oBwejXj+1UODsCjfw7Hxjod1Tl8TLOh/37
-        bYiaGbGxnNSSZSZvpQ+blu1Cec/lKHugabC2RLxr6nDXh3YyE87a3lxYrnsg
-        XgZEyncFdUcdlm5bftFdt7HtlqpipC2t2jJLDWDFM54ZIzjLirzimIBJpIZU
-        QDIrMdBjre5sNZTboGT8FzLiwhztJMuTgtpVhuRApgqUTlOBdIwyeRyLZ0D7
-        N+vnzeIB1slSpI9D/Q1I7x0eBTR/QpT5j4GYMc4TkfNMaCMyrpSEAgumOGag
-        VaKfAeJzbxs/9P//Rlnu8HsE5XSZHouyXBbyWJTjJ0Q5/jEoI6uMTplOFBfU
-        wjkoniNQAyf4K5Wlz4Hy+I68wHo49WtIF0cgvdd6aqRfRj2/H2fl3pl782un
-        wZVV47cHwZhswsvP7jKO0EPi98vmi5OsySqhTJxmeSGF5vTST1PF0wTjIhfA
-        7rz3v9ckG71uNm5x1ozsnObZ6Jf903yoPV2c2Wr8egiLtw2Y+VwbvWl82Fzt
-        R84nGG/l+GNxUfxPxtu+a7vy0xhcPNYEfbD9/Dx5OZ8nqr8e6v1nFb7oKhwa
-        7/5/kQqnf0i+pfEfkLzYvzaim38BAAD//wMABTbET6YRAAA=
+        H4sIAAAAAAAAA+xYUW/bNhD+K4aeU0OkKInyW7BkDwUWBMm2hw2FQJFHm6ssCRSV1C3y33ekLUdO2trFumUB6gdDPN6Rx/u+O570KZIWhANVChctIhoT/obQN4T/StJFki9S9kd0Fpm+tOAG20QLZwc4i9bQ92IJfbT48x2OWgVo7KB3qNx2zrQNTn2K5GAtNHKDk7/dXuBcJzZraJyfc5vOG91eXl1c3kQPZ1EtKqhLhc5Ei2ao67PIP5dC3YlGoixGHQsa/Ip7ld4JN+Be0dC8b9r7BvdwVsj3plmWMri11Rs6dfSUlXByVRo12mzH4w5T2e74o1AOvWvXfWka3Y4ybds1+q4sqvrj+mUjoWzJdK5yAZIRwVmSC54VCckUBeCUckl8BKu/QHpHz3f2Z8dQIt7/I2cMOo1YP7rdrjvRbB5DaQEcQVuSkNntjLvV7PwOonGG7u2M84j+Ipo7U9dbhYBadPUWBx9Nh48x50nqHW+HxtktAzwBVm0DwT3K0ozgD4WwFqYeVz8kkxTWGrClFtLUYd+tFobFKGSSEXtDDQqsqEsnPkxADK49kd2BNdpIMfL0AZllmn6wYsKs1uJyE6NOWAn1HsrOyrqUuhIsA8GTvGAyJVxnOTABGZVE4cwUy+ut/VEokxOgDDo1NEu3Gt27N+pxsAKzXLm95xYjo02D63WYGhPi3u/0SDyPDyOPEelajN0SypCX+7ijWz7rd1Hww1KCqmJWECh0zDjPhY4hU1zTXAJlCqZRuPFEORoDdkIMgs4hWXqwd8YjGP1s7JQ+gX3Xnn92S9RknsZ++ml9wiqHVCx3WmzO0kfhM+Xa9K48XDCInikqqA1yboPFbYPBoweSSbmbCsvlIJCPDgDjrEXdY9XFU5bP1+pXpvNFNXAVR10JQsuiimXOE8JynoosT0SRJlKmWmZFPMkrIUOCbm2lKNeuSsnvECMBphBTiqaZzBDNnDGqOSkYKPzLFKSaxS8A8bU1rfUV4csoZ/NtCfo6ytk8j09EOZun6akok++IMvlvUJZJwSqSFELyhBWpqmgqsUznSUw5S2XyEiiHqnkLtd/1a0inJyGdnprP34L0K8xnvK1kluMlDCxjMgHOiqzCTVRGWIbZ/QJIX37oxl7nCyBTMi/4cZQpOz2hxyVPwvkzqP4TqHf9yb+D9rvQKw+NetK/9lI0pW7tei8IqYWY2clxQgvtEdgN2892sjnNeKxFJQheDCn2sVRWRCVVrgvs/fjBpXByJ0tP4BF97GSjt+2qmV20gaFjPxv9tHuaNrXnswujw9uDm920Qk372uiqtW51v2s5v0N7m4ZfTIrif9LeDn3Xlx+DcySkBr7M/Xg9eT2vJ9Ww8fn+IwtfdRb6wrv7ZqJh/HryLYV/j+Tt7tqIHv4GAAD//wMAk0gx1MIRAAA=
     http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:44 GMT
+  recorded_at: Tue, 18 Dec 2018 15:37:54 GMT
 - request:
     method: post
-    uri: https://api.easypost.com/v2/shipments/shp_76daef2727dd420798f2e3ad35ca64a3/buy
+    uri: https://api.easypost.com/v2/shipments/shp_eafc9b0c78314785a673a953cc5fc690/buy
     body:
       encoding: UTF-8
-      string: rate[id]=rate_4291de51a98540519df9eae39a5c854e
+      string: rate[id]=rate_cedb0491e9f04887af0e6d8f27ce24de
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.7.0
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
@@ -637,7 +303,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ep-Request-Uuid:
-      - b3d7c8a6-af12-4d06-891a-39aa3e0f14b6
+      - 4bc380d6-5e60-455a-a38e-6b231399a12a
       Cache-Control:
       - no-cache, no-store, must-revalidate, private
       Pragma:
@@ -647,58 +313,26 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Runtime:
-      - '1.018328'
+      - '0.942459'
       Content-Encoding:
       - gzip
       Transfer-Encoding:
       - chunked
       X-Node:
-      - 0c5331f72e
-      - easypost
-      - web3sj
+      - bigweb8sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb5sj, 8657dcde98
+      - extlb1sj 130594cc1d
+      - intlb1sj 130594cc1d
       Strict-Transport-Security:
       - max-age=15768000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+xYbW/bNhD+K4E+Jw5FkXrxt2JpMRRL0K3JtmYoBIo82Upk
-        SaCouHaR/76jXmzZSRsPCxp0q79YPN6Rx3uOd7z77EgNwoCKhXGmDiVucEL4
-        CaGXlEwZmzLv2jl2sjrWYBpdOFOjGzh2FlDXYga1M/3rI45KBShsoDbIXFYm
-        Kwuc+uzIRmso5Aonr96f4VwuEshjhRs606LJ82PHfsdC3YlCIo3cHzsaUrBS
-        G5baCNPgek5T3BblssB1jBbyNitmsey2jlhAXM8PoyBkvksC3w2RgoxNpb52
-        Om5Plwgj53Gmhv268bDrmNYfeyDKpjbloo6zIi0HWqrLBZ5HaWS1JrDLOkLp
-        mEjwExX4YZpwFnCIfE4VVQkRMpUchLVccgPSKvqqlz8+CJ0nzsgsTyEWW7XL
-        RSWK1da8GsC4KOt67tH7o9DMj17dgTPM0I1cZiyS56K4y/K8Y2iRdC7e4mCd
-        VfhJwtDjJ27gcqt92RRGd/DjsJqXBbQ6UsZ9F39IhIXI8mGLXU+SQusMdJwK
-        meXt5h0X2iZTUJhMbARTUKBFHhvxaYRkq98e7Q50lmZSbJwU9Wb2v26kbEHr
-        XBy0LnXv4AoMKtk7w/09OmlW1I0WIyctNSow2qYSWkK+8YBKyzymyhVpSFgK
-        EbAoIRGBIOAqCWSoKOfu2AXedfLP4gEtTw7FzMwH9ZaZ2g7mkM3mZqO5Rlum
-        WYHrVXjLRv6+7PlcMiG7WKFFqhKtPYO4veL23NujdDO/tBPHvT3yOOGJ5wNL
-        OUOTKOARYUSkRHq+JJGMoqfPzg44e3vD94KMhc/ATLdyaakXKFlY19wNUF/a
-        seNBJyzzxnqRM/UIGch1trai7JO/4TSrypLQqKLJzYacZjkMc9kCDXRaFbPN
-        bKPRiM7cmKqenp6CqFfWwCdWqJ7U3klTnyzR8id0IhZiXRZiWU/wYp+2DKc7
-        YJzacxBO6KknXSkgUpL5EZM0SSgLXJcxP02DMBR0MtagUmmnRQd+R1xX+UMi
-        VDl9SLWa9DcGryxa1F6m/jrYYcxo5CLurohCzgh3I5VGIMCLBJdIgfF1+M0i
-        8iwO0fLsxpka9F1mPcN5/akaAm8Xe9rQ9c4GL937hDtxQzu/n9p0GyPigc2b
-        BHxLfZgIs9rEe0u2tAecCvIMY9YKnXK1SUcj4iiVjonxrBEYoAwA2jsVeW1D
-        Gq7/6HL1PKsWGFDb+IWjKg58JSClAQ2UYpQEUZhS8ITyuBQ+E94oOgvZhvlO
-        Vop4YRLu/g4Eg8IYbS8IvQjTXQC4APcTkUjfZ4DbJCpEJ3wBtN9kepxnHmDt
-        TZj/NNT/AOl+wYOAps+IMv02EBNCqcdCGjCpWIDhhYsIIpJQCIRMPPkCEL/T
-        Want0+HLKPMOvydQ9if+oSjzScQPRdl9RpTdb4MykFRJH/M0Zg8M4VQkNASB
-        ARzhT5PAfwmU28fSe8jtrl9DOjoA6Z7ruZH+Pu7zx7b+agq1V//UUhT9U6kn
-        tMZGvDpT/Mjr/6e83tXf1oo97kbfxmFCI+lzP+VUMgIQCU8pP3Sx2g2J6+7E
-        hctefh+xg+v6R3oCHSnuarWdmSe8ix9aRtTZzFZFyWq/IOpGezBsAfw3MGwd
-        dWObTTVqS9MUhi7MgNtggL6aa5I8k3vlRLvUZCgq2rpB3bz21c9v9Z/reXZ+
-        k99c3FzR65ur1Yf1r8vrP674h8uL2+uzD+z88opcrGfL88vXtPWE8tFuhwpS
-        lijXD8KIY6WBAcD3E+p74EYhE2QnBjxrt8Pbdjuct+W8ODor2wAz9Dycn/qv
-        cePj1dFZlrZdJ3P0WynUuPfhXJTazJd9R+LgFsiXux+8/RG3rXBfuvthexlN
-        XdXxulXObSNbo4sfLaz/fAsraVY2yv+4vN/15bVvst1UMOq8vQF7yr7H1Pbf
-        OopY2NPZ006IR4hNqHIu9My+KTrX6R6BmzeGrQAeX7Vv7u2t2z59Dlr4Y98Q
-        PDArbpR43+dU5/5vAAAA//8DABjGMIPDGAAA
+        H4sIAAAAAAAAA+xYbW/bNhD+K4E+Jw4pkRTlb9mSYiiWrGuSde1QCBR5stXKkkBRcewi/32kXhzZaRpv7Va0qD8k4vFIHu957kjeB09qEAZULIw39XyE+RH2jzC/wnQahFNK3niHXlbHGkyjC29qdAOH3gLqWsyg9qZ/vbWtUoEdbKA2VrmsTFYWtuuDJxutoZAr23l9eWr7KrFaQGFcn1lVbtDl2cXp2Uvv7tDLRQJ5rKwx3rRo8vzQc9+xUDeikFaGrI6GFNyMG5XaCNPYtbymeF+Uy8KuYbSQ77NiFsvOrIgghAPGo5ATZvfHfYxYZBWbSn1q58ztPBFGzuNMDet17WHVsax3ySCUTW3KRR1nRVoOslSXC7sfpa2qc4Gb1hNKxyQNVShAEiw4CULBWRRgpnwA7vtcYufV5B1IZ+hJP/7wKeTwm6f3SJ1OIRb3ZpeLShSre/dqAIPtWBzgg8sDbuYHJzfgDT3+ZlxmHMrnorjJ8rxTaJH0Lp7bxjqr7CfiPKBHOMTUWV82hdEdNRwz5mUBrY0+oQzbnxXCQmT5sMQ2y6TQOgMdp0Jmebt4p2V9kylLsUzkA1lTUKBFHhtxO0KytW9HdgM6SzMpNgS2dhP3v26kbEHrZgStS92TX4GxRvZkuLuzJM2KutFiRNJSWwNGy1RCS8g3DKi0zGOZJoIwEDwIIyIp5ikLgQhgvsTK9owp8KIb/yQDgj0Y0OrkUMzMfDBvman7xhyy2dxsLNfWl2lW2PkqG2Ujvi97PYwmaBsr65GqtN6eQdyGuNv3/Va6nl/bjsPeH3kMKk1SHCgkwScBU1EQAEtYAJwlkKbo6b2zPfbe6uwkGQefgZlux6WlXtiRhaPmdoJ6bLZOx5KwzBvHIm8aIDSI62zthpJbttHss6B1qmhysxGnWQ5DX7awDjquitmmt9HWid7cmKqeHh+DqFfOwUduUD2pg6OmPlpazx/5E7EQ67IQy3piA/u4VTjeAuPY7QP7mB8zFTAfB5T4CIhPZZQiTjgICEPEKFaTsQWVSjsrOvA74brKHwqhyv2HUmdJHzE2ZK1HXTD14eCasQSVIBJhsGYQzkORImCKp37oGKFgHA4vHSJPEoLsQYhWZzvP1KBvMscM71mmx5mnTVwvXOrSHSOCCW15uXvm6TZBxL0WmRB6L3ygnGe1ibcnbEUPFBXkmU1XK8vHlXWevyUZHaFjYTxrhE1MBsD6ORV57VKZnfzhXPU8q9xB3SYt26piEKmMEiRDHmAScipYGIiIBlLSVLIIjVKykG1u78ZKES9MQvEfgGwmGEPs+3Yok8yiGRLipxxHBJT9wxTQlKCvAPELnZXaHSaPo8wmAX0aZTYJ0Z4oswml+6KMvyDK+P9BWQYRSXAQCckDElGV2NRiT/gwQD4nVAZfA+X2+LyE3K36KaTpXkjTfeP5nyD9DcazvbZIFtr7GxBGpD2qScQSu4himDAb3V8B6bPbargrPwKyjycRfxpln+wf0MOUe+H8EVQ/B+r+avvfoP22fX81hdp5/9RSFP1VqRe0oWUx6zzy41z/7s/17tHtnNeDbfT7mCJJaaQiiiKwkAvuMxwAYoLLIKBoC+urfvwuTHs/5j9SCOhEcfdA2+r5Um+HOpu5p1Cy2n0Fda0dDO7R+xwY7vm58c3mCereoykMZZkBt8EB/ROuSfJM7rwh2qkmw0uifSyod2dM/fJc/7m+Xr5eX+PfXv1OL65O6Jur3+n5qzNy/u717bl/vbxYnJHX6/P1xdVPecuE8qMljtBnHKUiEdje+ChnkS8TrIIkTCMeUL5129u7xOHvAZR/X+Lwnpfz4uC0bLPKUOjwfu6/xtWOk4PTLG1LTebgZSnUuODhXZTazJd9GWLvusfjJQ/a/hCOoi9Q8ugrTf+65OEKGE1d1fG6NQ63Ka3RxY+61Xdft0qalcvyP4L3mw5edxHbPgpG5bZn4HbZF5baolsnEQu3O7fbCcIItcfNXOiZu1B01OlufpsLhrv6f3zWvqK3M6+78+w179u+CLjnobix4bI/Ur27vwEAAP//AwBvv+l00xgAAA==
     http_version: 
-  recorded_at: Tue, 02 May 2017 20:44:45 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 18 Dec 2018 15:37:56 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/Spree_EasyPost_ReturnAuthorization/_return_label/has_the_correct_fields.yml
+++ b/spec/cassettes/Spree_EasyPost_ReturnAuthorization/_return_label/has_the_correct_fields.yml
@@ -4,559 +4,336 @@ http_interactions:
     method: post
     uri: https://api.easypost.com/v2/addresses
     body:
-      encoding: US-ASCII
-      string: address[street1]=215%20N%207th%20Ave&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[state]=NJ&address[country]=US
     headers:
       Accept:
-      - "*/*; q=0.5, application/xml"
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
       - application/x-www-form-urlencoded
       Content-Length:
-      - '221'
+      - '148'
+      Host:
+      - api.easypost.com
   response:
     status:
       code: 201
       message: Created
     headers:
-      Date:
-      - Tue, 08 Dec 2015 23:06:57 GMT
-      Status:
-      - 201 Created
-      Connection:
-      - close
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
       - 1; mode=block
       X-Content-Type-Options:
       - nosniff
+      X-Ep-Request-Uuid:
+      - 7ab50325-fcb1-44ff-909c-7032a83da006
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
       Location:
-      - "/api/v2/addresses/adr_d20397df79f3410fa4d4deb5bd58c3dc"
+      - "/api/v2/addresses/adr_82b19dcafd12401c8eaef1a44049b4dd"
       Content-Type:
       - application/json; charset=utf-8
-      Etag:
-      - W/"430f08aeea6039156387c44f09ad14e2"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 1eaa42f6-0911-4533-986b-94705a8d7e2e
       X-Runtime:
-      - '0.045160'
+      - '0.048442'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
       X-Node:
-      - web6sj, 853f9c221e
+      - bigweb4sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb5sj, b89c00fb8c
+      - extlb1wdc 130594cc1d
+      - intlb1wdc 130594cc1d
+      - intlb2sj 130594cc1d
       Strict-Transport-Security:
-      - max-age=86400
+      - max-age=15768000; includeSubDomains; preload
     body:
-      encoding: UTF-8
-      string: '{"id":"adr_d20397df79f3410fa4d4deb5bd58c3dc","object":"Address","created_at":"2015-12-08T23:06:57Z","updated_at":"2015-12-08T23:06:57Z","name":"John
-        Doe","company":"Company","street1":"215 N 7th Ave","street2":"Northwest","city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"5555550199","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}}'
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SQsW7DMAxEfyXQ3ACmIheKt6wF2iXt0sWgTRpRIEuGLBttg/x76QTO0KWaxNM78sSLcqQqhZRqqxvYU4sdgTYFtJaRO0BjCrNvDJF6UrE5c5uFPxAlHkeR2sSYmWpcZF2A3YLegn2HsjJFpeFTmGmgf5mAPasqTN5Lz9gPGL7XcsyJOYN4YQeb48bm0+Yws1pf9MPnspjUK4bZeX8HZLBIby9S/LhBroW1u3IJHqeQ08J/HKUcTjHwLZ425TPIEZF7dH7t3kdagMxjXuyYkuNUd9g6f5t7p2Qtjjhkhw9jx8QJfZ3xq162vf5Kov3RZk6ucy1mF8Ooqsv1+gsAAP//AwAjVg6RoAEAAA==
     http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:00 GMT
+  recorded_at: Tue, 18 Dec 2018 15:40:21 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/addresses
     body:
-      encoding: US-ASCII
-      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[company]=Spree%20Test%20Store%2035&address[state]=NJ&address[country]=US
+      encoding: UTF-8
+      string: address[street1]=A%20Different%20Road&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
     headers:
       Accept:
-      - "*/*; q=0.5, application/xml"
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
       - application/x-www-form-urlencoded
       Content-Length:
-      - '191'
+      - '222'
+      Host:
+      - api.easypost.com
   response:
     status:
       code: 201
       message: Created
     headers:
-      Date:
-      - Tue, 08 Dec 2015 23:06:57 GMT
-      Status:
-      - 201 Created
-      Connection:
-      - close
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
       - 1; mode=block
       X-Content-Type-Options:
       - nosniff
+      X-Ep-Request-Uuid:
+      - de9d12b8-2132-4d34-92c5-2681f9ee1cad
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
       Location:
-      - "/api/v2/addresses/adr_bb622d9509724f3da12180181b71438d"
+      - "/api/v2/addresses/adr_330a6e7ecb7c4c1cab56f4c445e9e1f3"
       Content-Type:
       - application/json; charset=utf-8
-      Etag:
-      - W/"7b8a3fa0e2536a78e8c232a73180196f"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 83de7fc9-4443-46f4-8f88-34363ef75541
       X-Runtime:
-      - '0.042928'
+      - '0.049751'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
       X-Node:
-      - web14sj, 853f9c221e
+      - bigweb3sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb5sj, b89c00fb8c
+      - extlb2sj 130594cc1d
+      - intlb1sj 130594cc1d
       Strict-Transport-Security:
-      - max-age=86400
+      - max-age=15768000; includeSubDomains; preload
     body:
-      encoding: UTF-8
-      string: '{"id":"adr_bb622d9509724f3da12180181b71438d","object":"Address","created_at":"2015-12-08T23:06:57Z","updated_at":"2015-12-08T23:06:57Z","name":null,"company":"Spree
-        Test Store 35","street1":"131 S 8th Ave","street2":null,"city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"2024561111","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}}'
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SRu27DMAxFfyXQnACWH4ntLWimAO3Qx9LFoCUKYSFLhqykjyD/XsoJMnSpJvLy6PJCOgvSohWgQ1cUGaxxg6rfqFJJBX21NqUqywoblKYQS+H7D1SR+a3WAaeJJRUQIuoOkpxnsl7JfCXrV1m1Zdbm+Tszx1H/yzgYkKd7f3CLncfk7IcR3DeLD7dqKaYYEKNMCRY7MgYDurh49qDvw5yHTz7EwydOMdlQTB6P4E5kLc4cp0nUnpsfGrnM6rqo5p1HF0Pi3164HQ/eJbKaTyabhkUcgKxo3dHapRi8TkC87YIQCENnQJGd914pfivSnJTgftGgxgC2i/DVpS+4qnO0P9oJAxlSEMm7SbTny+UXAAD//wMA84gOhbUBAAA=
     http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:01 GMT
+  recorded_at: Tue, 18 Dec 2018 15:40:22 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/parcels
     body:
-      encoding: US-ASCII
-      string: parcel[weight]=10.0
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
-      Authorization:
-      - Bearer CvzYtuda6KRI9JjG7SAHbA
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Content-Length:
-      - '19'
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Tue, 08 Dec 2015 23:06:58 GMT
-      Status:
-      - 201 Created
-      Connection:
-      - close
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Location:
-      - "/api/v2/parcels/prcl_7b63e434b5074110887fce9878eed538"
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"51a0cd70cf086f537a407bbb3827f9aa"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 624032c2-3161-463e-bff7-523eacd374cf
-      X-Runtime:
-      - '0.029287'
-      X-Node:
-      - web11sj, 853f9c221e
-      X-Backend:
-      - easypost
-      X-Proxied:
-      - lb5sj, b89c00fb8c
-      Strict-Transport-Security:
-      - max-age=86400
-    body:
       encoding: UTF-8
-      string: '{"id":"prcl_7b63e434b5074110887fce9878eed538","object":"Parcel","created_at":"2015-12-08T23:06:57Z","updated_at":"2015-12-08T23:06:57Z","length":null,"width":null,"height":null,"predefined_package":null,"weight":10.0,"mode":"test"}'
-    http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:01 GMT
-- request:
-    method: post
-    uri: https://api.easypost.com/v2/shipments
-    body:
-      encoding: US-ASCII
-      string: shipment[to_address][id]=adr_d20397df79f3410fa4d4deb5bd58c3dc&shipment[from_address][id]=adr_bb622d9509724f3da12180181b71438d&shipment[parcel][id]=prcl_7b63e434b5074110887fce9878eed538
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
-      Authorization:
-      - Bearer CvzYtuda6KRI9JjG7SAHbA
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Content-Length:
-      - '184'
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Tue, 08 Dec 2015 23:06:59 GMT
-      Status:
-      - 201 Created
-      Connection:
-      - close
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Location:
-      - "/account/shipments/shp_b69897f35b5743899ede8df57c3b0896"
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"831230825fdd96136823d4333773dce6"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 283c964e-ded2-4907-82c6-48ee8dbf8e51
-      X-Runtime:
-      - '0.918784'
-      X-Node:
-      - web15sj, 853f9c221e
-      X-Backend:
-      - easypost
-      X-Proxied:
-      - lb5sj, b89c00fb8c
-      Strict-Transport-Security:
-      - max-age=86400
-    body:
-      encoding: UTF-8
-      string: '{"created_at":"2015-12-08T23:06:58Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","label_date":null},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2015-12-08T23:06:58Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_bb622d9509724f3da12180181b71438d","object":"Address","created_at":"2015-12-08T23:06:57Z","updated_at":"2015-12-08T23:06:57Z","name":null,"company":"Spree
-        Test Store 35","street1":"131 S 8th Ave","street2":null,"city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"2024561111","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}},"insurance":null,"parcel":{"id":"prcl_7b63e434b5074110887fce9878eed538","object":"Parcel","created_at":"2015-12-08T23:06:57Z","updated_at":"2015-12-08T23:06:57Z","length":null,"width":null,"height":null,"predefined_package":null,"weight":10.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_fe6c9a8f77aa4a209aca9dcd6117a163","object":"Rate","created_at":"2015-12-08T23:06:58Z","updated_at":"2015-12-08T23:06:58Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"5.70","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"5.70","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":null,"shipment_id":"shp_b69897f35b5743899ede8df57c3b0896","carrier_account_id":"ca_mtb51Ve0"},{"id":"rate_6d1dff79782e45afb321ead77cfb9b82","object":"Rate","created_at":"2015-12-08T23:06:58Z","updated_at":"2015-12-08T23:06:58Z","mode":"test","service":"First","carrier":"USPS","rate":"3.07","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"3.07","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":null,"shipment_id":"shp_b69897f35b5743899ede8df57c3b0896","carrier_account_id":"ca_mtb51Ve0"},{"id":"rate_fc57250217d24510be2b4633dcd7b656","object":"Rate","created_at":"2015-12-08T23:06:58Z","updated_at":"2015-12-08T23:06:58Z","mode":"test","service":"Priority","carrier":"USPS","rate":"5.05","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"5.05","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":null,"shipment_id":"shp_b69897f35b5743899ede8df57c3b0896","carrier_account_id":"ca_mtb51Ve0"},{"id":"rate_eef8e287158b4828a6fe9e8159cc1283","object":"Rate","created_at":"2015-12-08T23:06:58Z","updated_at":"2015-12-08T23:06:58Z","mode":"test","service":"Express","carrier":"USPS","rate":"15.13","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"15.13","list_currency":"USD","delivery_days":0,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":0,"shipment_id":"shp_b69897f35b5743899ede8df57c3b0896","carrier_account_id":"ca_mtb51Ve0"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_d20397df79f3410fa4d4deb5bd58c3dc","object":"Address","created_at":"2015-12-08T23:06:57Z","updated_at":"2015-12-08T23:06:57Z","name":"John
-        Doe","company":"Company","street1":"215 N 7th Ave","street2":"Northwest","city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"5555550199","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_bb622d9509724f3da12180181b71438d","object":"Address","created_at":"2015-12-08T23:06:57Z","updated_at":"2015-12-08T23:06:57Z","name":null,"company":"Spree
-        Test Store 35","street1":"131 S 8th Ave","street2":null,"city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"2024561111","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_d20397df79f3410fa4d4deb5bd58c3dc","object":"Address","created_at":"2015-12-08T23:06:57Z","updated_at":"2015-12-08T23:06:57Z","name":"John
-        Doe","company":"Company","street1":"215 N 7th Ave","street2":"Northwest","city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"5555550199","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_b69897f35b5743899ede8df57c3b0896","object":"Shipment"}'
-    http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:02 GMT
-- request:
-    method: post
-    uri: https://api.easypost.com/v2/addresses
-    body:
-      encoding: US-ASCII
-      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[company]=Spree%20Test%20Store%2035&address[state]=NJ&address[country]=US
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
-      Authorization:
-      - Bearer CvzYtuda6KRI9JjG7SAHbA
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Content-Length:
-      - '191'
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Tue, 08 Dec 2015 23:06:59 GMT
-      Status:
-      - 201 Created
-      Connection:
-      - close
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Location:
-      - "/api/v2/addresses/adr_7cd6e8c2ae7948058f5023e466ce0350"
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"c54b16bf07d47e4a08fb1852a18818a7"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - d123914f-c6a8-4d4a-a7ba-ca8505976814
-      X-Runtime:
-      - '0.037595'
-      X-Node:
-      - web3sj, 853f9c221e
-      X-Backend:
-      - easypost
-      X-Proxied:
-      - lb5sj, b89c00fb8c
-      Strict-Transport-Security:
-      - max-age=86400
-    body:
-      encoding: UTF-8
-      string: '{"id":"adr_7cd6e8c2ae7948058f5023e466ce0350","object":"Address","created_at":"2015-12-08T23:06:59Z","updated_at":"2015-12-08T23:06:59Z","name":null,"company":"Spree
-        Test Store 35","street1":"131 S 8th Ave","street2":null,"city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"2024561111","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}}'
-    http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:02 GMT
-- request:
-    method: post
-    uri: https://api.easypost.com/v2/addresses
-    body:
-      encoding: US-ASCII
-      string: address[street1]=215%20N%207th%20Ave&address[street2]=Northwest&address[city]=Manville&address[zip]=08835&address[phone]=555-555-0199&address[company]=Company&address[name]=John%20Doe&address[state]=NJ&address[country]=US
-    headers:
-      Accept:
-      - "*/*; q=0.5, application/xml"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
-      Authorization:
-      - Bearer CvzYtuda6KRI9JjG7SAHbA
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Content-Length:
-      - '221'
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Tue, 08 Dec 2015 23:06:59 GMT
-      Status:
-      - 201 Created
-      Connection:
-      - close
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Location:
-      - "/api/v2/addresses/adr_06db640cc9654b46b8cc3bcdcba97a02"
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"88393b8f49ba140d8047f143f0663e48"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 947adcce-ae2f-4123-99d5-9b3095a06ccb
-      X-Runtime:
-      - '0.039681'
-      X-Node:
-      - web3sj, 853f9c221e
-      X-Backend:
-      - easypost
-      X-Proxied:
-      - lb5sj, b89c00fb8c
-      Strict-Transport-Security:
-      - max-age=86400
-    body:
-      encoding: UTF-8
-      string: '{"id":"adr_06db640cc9654b46b8cc3bcdcba97a02","object":"Address","created_at":"2015-12-08T23:06:59Z","updated_at":"2015-12-08T23:06:59Z","name":"John
-        Doe","company":"Company","street1":"215 N 7th Ave","street2":"Northwest","city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"5555550199","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}}'
-    http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:03 GMT
-- request:
-    method: post
-    uri: https://api.easypost.com/v2/parcels
-    body:
-      encoding: US-ASCII
       string: parcel[weight]=10
     headers:
       Accept:
-      - "*/*; q=0.5, application/xml"
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
       - application/x-www-form-urlencoded
       Content-Length:
       - '17'
+      Host:
+      - api.easypost.com
   response:
     status:
       code: 201
       message: Created
     headers:
-      Date:
-      - Tue, 08 Dec 2015 23:07:00 GMT
-      Status:
-      - 201 Created
-      Connection:
-      - close
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
       - 1; mode=block
       X-Content-Type-Options:
       - nosniff
+      X-Ep-Request-Uuid:
+      - cc89f044-ec48-4e2b-bc1f-b690a8ae5bda
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
       Location:
-      - "/api/v2/parcels/prcl_f489d7b28ec9493a8f843485f1fc5b29"
+      - "/api/v2/parcels/prcl_20d8eeeba2b64f30aeb34e052fbae098"
       Content-Type:
       - application/json; charset=utf-8
-      Etag:
-      - W/"6d4e1251269738a84383d24699aee7e0"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - ed6da558-2e7e-4279-ae88-62f83a0e7142
       X-Runtime:
-      - '0.032842'
+      - '0.032866'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
       X-Node:
-      - web14sj, 853f9c221e
+      - bigweb3sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb5sj, b89c00fb8c
+      - extlb2wdc 130594cc1d
+      - intlb1sj 130594cc1d
+      - intlb1wdc 130594cc1d
       Strict-Transport-Security:
-      - max-age=86400
+      - max-age=15768000; includeSubDomains; preload
     body:
-      encoding: UTF-8
-      string: '{"id":"prcl_f489d7b28ec9493a8f843485f1fc5b29","object":"Parcel","created_at":"2015-12-08T23:07:00Z","updated_at":"2015-12-08T23:07:00Z","length":null,"width":null,"height":null,"predefined_package":null,"weight":10.0,"mode":"test"}'
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4SMOw7CMBBE77J1gtZOgoxPQUFFE63tTWIwiWUcUSDujpH4lJTz5s3cwTvQEJMNvUSnmNmQNNt2aJDYNC1jJwdDjDsFFSzmxDaXwZ6S5VCITUyZXU8vKlGoWshaqIPodItaNsfirNH9dQLPY55Az2sIFdy8+4WJ/TjlT4qJHQ9+Ln+R7JlG/o7ensANVnBZXGkg8zXD4wkAAP//AwAUDMhJ5wAAAA==
     http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:03 GMT
+  recorded_at: Tue, 18 Dec 2018 15:40:23 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/shipments
     body:
-      encoding: US-ASCII
-      string: shipment[from_address][id]=adr_7cd6e8c2ae7948058f5023e466ce0350&shipment[to_address][id]=adr_06db640cc9654b46b8cc3bcdcba97a02&shipment[parcel][id]=prcl_f489d7b28ec9493a8f843485f1fc5b29&shipment[is_return]=true
+      encoding: UTF-8
+      string: shipment[from_address][id]=adr_82b19dcafd12401c8eaef1a44049b4dd&shipment[to_address][id]=adr_330a6e7ecb7c4c1cab56f4c445e9e1f3&shipment[parcel][id]=prcl_20d8eeeba2b64f30aeb34e052fbae098&shipment[is_return]=true
     headers:
       Accept:
-      - "*/*; q=0.5, application/xml"
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
       - application/x-www-form-urlencoded
       Content-Length:
       - '209'
+      Host:
+      - api.easypost.com
   response:
     status:
       code: 201
       message: Created
     headers:
-      Date:
-      - Tue, 08 Dec 2015 23:07:01 GMT
-      Status:
-      - 201 Created
-      Connection:
-      - close
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
       - 1; mode=block
       X-Content-Type-Options:
       - nosniff
+      X-Ep-Request-Uuid:
+      - f6209ad7-dcdd-4fc8-a545-816a3d20a3f8
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
       Location:
-      - "/account/shipments/shp_ca8cd21cab604f0ea3c3bd7868702a1c"
+      - "/api/v2/shipments/shp_5a01bebcf1334033bd09b501077fefd7"
       Content-Type:
       - application/json; charset=utf-8
-      Etag:
-      - W/"39bc5c3c2138835433f7037e2d318b75"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - b2cf5f7c-228e-4769-ac8f-9e89fedbe686
       X-Runtime:
-      - '1.023624'
+      - '0.322076'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
       X-Node:
-      - web11sj, 853f9c221e
+      - bigweb1sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb5sj, b89c00fb8c
+      - extlb1sj 130594cc1d
+      - intlb2sj 130594cc1d
       Strict-Transport-Security:
-      - max-age=86400
+      - max-age=15768000; includeSubDomains; preload
     body:
-      encoding: UTF-8
-      string: '{"created_at":"2015-12-08T23:07:00Z","is_return":true,"messages":[],"mode":"test","options":{"currency":"USD","label_date":null},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2015-12-08T23:07:00Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_7cd6e8c2ae7948058f5023e466ce0350","object":"Address","created_at":"2015-12-08T23:06:59Z","updated_at":"2015-12-08T23:06:59Z","name":null,"company":"Spree
-        Test Store 35","street1":"131 S 8th Ave","street2":null,"city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"2024561111","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}},"insurance":null,"parcel":{"id":"prcl_f489d7b28ec9493a8f843485f1fc5b29","object":"Parcel","created_at":"2015-12-08T23:07:00Z","updated_at":"2015-12-08T23:07:00Z","length":null,"width":null,"height":null,"predefined_package":null,"weight":10.0,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_ade0e2c893e647ab912aa184fef8561a","object":"Rate","created_at":"2015-12-08T23:07:01Z","updated_at":"2015-12-08T23:07:01Z","mode":"test","service":"First","carrier":"USPS","rate":"3.07","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"3.07","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":null,"shipment_id":"shp_ca8cd21cab604f0ea3c3bd7868702a1c","carrier_account_id":"ca_mtb51Ve0"},{"id":"rate_3e9a4ea055254dbda6e751d577eda4de","object":"Rate","created_at":"2015-12-08T23:07:01Z","updated_at":"2015-12-08T23:07:01Z","mode":"test","service":"Priority","carrier":"USPS","rate":"5.05","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"5.05","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":null,"shipment_id":"shp_ca8cd21cab604f0ea3c3bd7868702a1c","carrier_account_id":"ca_mtb51Ve0"},{"id":"rate_053f7ca345b246ab812529ad358512e6","object":"Rate","created_at":"2015-12-08T23:07:01Z","updated_at":"2015-12-08T23:07:01Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"5.70","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"5.70","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":null,"shipment_id":"shp_ca8cd21cab604f0ea3c3bd7868702a1c","carrier_account_id":"ca_mtb51Ve0"},{"id":"rate_ab5d42db16804593918de666c9d393f9","object":"Rate","created_at":"2015-12-08T23:07:01Z","updated_at":"2015-12-08T23:07:01Z","mode":"test","service":"Express","carrier":"USPS","rate":"15.13","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"15.13","list_currency":"USD","delivery_days":0,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":0,"shipment_id":"shp_ca8cd21cab604f0ea3c3bd7868702a1c","carrier_account_id":"ca_mtb51Ve0"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_06db640cc9654b46b8cc3bcdcba97a02","object":"Address","created_at":"2015-12-08T23:06:59Z","updated_at":"2015-12-08T23:06:59Z","name":"John
-        Doe","company":"Company","street1":"215 N 7th Ave","street2":"Northwest","city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"5555550199","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_7cd6e8c2ae7948058f5023e466ce0350","object":"Address","created_at":"2015-12-08T23:06:59Z","updated_at":"2015-12-08T23:06:59Z","name":null,"company":"Spree
-        Test Store 35","street1":"131 S 8th Ave","street2":null,"city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"2024561111","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_06db640cc9654b46b8cc3bcdcba97a02","object":"Address","created_at":"2015-12-08T23:06:59Z","updated_at":"2015-12-08T23:06:59Z","name":"John
-        Doe","company":"Company","street1":"215 N 7th Ave","street2":"Northwest","city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"5555550199","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_ca8cd21cab604f0ea3c3bd7868702a1c","object":"Shipment"}'
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xY32/bNhD+Vww9pwZJkfrht2DJHgosCJJtDxsK4UQeba6yJFBUUrfI/z5Stmwl6WoXCJoFqJ7E4x15vO+740lfImkRHKoCXLSIGKHZO8re0ex3KhacLBj/KzqLTFdYdL2to4WzPZ5Fa+w6WGIXLf7+4EeNQm/ssHNeuWmdaWo/9SWSvbVYy42f/OP2ws+1sFlj7cKc27TB6Pby6uLyJno4iyoosSqUdyZa1H1VnUXhvQB1B7X0MuJ1LGoMK+5VOgeu93tFff2xbu5rv4ezID+aelnIwa2tXt+qo6cswclVYdRosx2PO0xlu+OPQtl3rll3hal1M8q0bdbed2W9ajhuWDYCZYuMlTRXErSijBMqMwTUFDgnPC+5UiGC5T8og6PnO/uzYyjR4P+RMw46NawPbjfrFurNIZQW0VFvS2M6u51lbjU7v8NonGF7O+MCor9BfWeqaqswoBZdvfeDz6b1ryTLYhEcb/ra2S0DAgFWTY2De4yLhPrHC3ENphpXf0wmCdYatIUGaaph362WD4tRnkkG9oYaFVqoCgefJiAOrj2R3aE12kgYefrgmWXqrrcwYVZj/XIToxasxGoPZWtlVTCiMkQsgZUJ1zEBLGOORDBdApI8m2J5vbU/CmV8ApSDToX10q1G9+6NOgxWaJYrt/fc+shoU/v1Wp8aE+Le7/QomZPHkfcRaRsfuyUWQ17u4+7dClm/i0IYFhSIIoJmUrGMEy1KiSLTmeBZzhSIeBqFm0CUozHgJ8Rg0HlMlg7tnQkIRpef2jFxtgQa+HcdGGi3VGV0PuDzrET5QufZWIxqfJ6Sg/SZdmU6VzxZcpA901RYGU+8ja9wm305mQgnZW8qLJY9eF46RB9vDVXnq68/bfHV5bqVaUN9HWjrR20hgNASS6lpHHMSx6UieSkIJWmqUat0kmIgh1zd2koo1q4U9E8kngtTtFlMRIJpkkke85QkZckgjRMeK8IE5OIV0P7V2GmxeIZ1PBfkONR8zsWJSO8WPAlo9oIosx8DsV8DUqAyp9onsYrzBIGmIqO0TBlq+QoQX1vT2FD//xvlZL69cL6NcnJ6PidzIU5Fmb4gyvTHoJxzIfOE5CnhkkMqSsY4iExxmaYgS/IaKA935C1WYddvIS1OQlqcms/fg/TbyOcPQ6/c1+pJ/9pJqAvd2PVeMATb42UnZxla6BD43bD5aicb+4bH3wQoy1RySSWUItGeS1xgjlQ/uvdP7mTZCRxih042et+s6tlFM7Bz7GejX3Zv06b2fHZh9PD14GY3DahpXxtdNdat7nct5wu0t2J4CM3z/0l723dtV3wenKNDTviPuZ+fJ2/n86TsNyHff2bhm87CUHh3/0w0jn9Pvqfw75G83V0b0cO/AAAA//8DANYciJ3CEQAA
     http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:04 GMT
+  recorded_at: Tue, 18 Dec 2018 15:40:24 GMT
 - request:
     method: post
-    uri: https://api.easypost.com/v2/shipments/shp_ca8cd21cab604f0ea3c3bd7868702a1c/buy
+    uri: https://api.easypost.com/v2/shipments/shp_5a01bebcf1334033bd09b501077fefd7/buy
     body:
-      encoding: US-ASCII
-      string: rate[id]=rate_ade0e2c893e647ab912aa184fef8561a
+      encoding: UTF-8
+      string: rate[id]=rate_1a0d0518cd2840f5bce58f854892da53
     headers:
       Accept:
-      - "*/*; q=0.5, application/xml"
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - EasyPost/v2 RubyClient/2.1.9
+      - EasyPost/v2 RubyClient/3.0.1
       Authorization:
       - Bearer CvzYtuda6KRI9JjG7SAHbA
       Content-Type:
       - application/x-www-form-urlencoded
       Content-Length:
       - '46'
+      Host:
+      - api.easypost.com
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Tue, 08 Dec 2015 23:07:03 GMT
-      Status:
-      - 200 OK
-      Connection:
-      - close
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
       - 1; mode=block
       X-Content-Type-Options:
       - nosniff
+      X-Ep-Request-Uuid:
+      - 98096466-ef01-4213-bf36-daa1bee94a65
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
       Content-Type:
       - application/json; charset=utf-8
-      Etag:
-      - W/"940870a041a07cf004cfeabb65c34b7f"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - c4970565-9e39-4e0f-9121-e8a0f3875df3
       X-Runtime:
-      - '1.752318'
+      - '1.094804'
+      Content-Encoding:
+      - gzip
+      Transfer-Encoding:
+      - chunked
       X-Node:
-      - web3sj, 853f9c221e
+      - bigweb6sj
+      X-Version-Label:
+      - easypost-201812180052-0a8d062527-master
       X-Backend:
       - easypost
       X-Proxied:
-      - lb5sj, b89c00fb8c
+      - extlb1wdc 130594cc1d
+      - intlb1sj 130594cc1d
+      - intlb1wdc 130594cc1d
       Strict-Transport-Security:
-      - max-age=86400
+      - max-age=15768000; includeSubDomains; preload
     body:
-      encoding: UTF-8
-      string: '{"postage_label":{"id":"pl_b0e149176a7b4313bb1d982705e71da6","object":"PostageLabel","created_at":"2015-12-08T23:07:02Z","updated_at":"2015-12-08T23:07:02Z","date_advance":0,"integrated_form":"none","label_date":"2015-12-08T23:07:00Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_url":"http://assets.geteasypost.com/postage_labels/labels/20151208/c2e6cfedd0744e598ae2d9266f97aaed.png","label_file_type":"image/png","label_pdf_url":null,"label_epl2_url":null,"label_zpl_url":null},"tracking_code":"9499907123456123456781","tracker":{"id":"trk_e62688bbf322406baafd36f921b981b7","object":"Tracker","mode":"test","tracking_code":"9499907123456123456781","status":"unknown","created_at":"2015-12-08T23:07:03Z","updated_at":"2015-12-08T23:07:03Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_ca8cd21cab604f0ea3c3bd7868702a1c","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null},"insurance":null,"selected_rate":{"id":"rate_ade0e2c893e647ab912aa184fef8561a","object":"Rate","created_at":"2015-12-08T23:07:01Z","updated_at":"2015-12-08T23:07:01Z","mode":"test","service":"First","carrier":"USPS","rate":"3.07","currency":"USD","retail_rate":null,"retail_currency":null,"list_rate":"3.07","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":null,"est_delivery_days":null,"shipment_id":"shp_ca8cd21cab604f0ea3c3bd7868702a1c","carrier_account_id":"ca_mtb51Ve0"},"forms":[],"messages":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.05000","charged":false,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"3.07000","charged":false,"refunded":false}]}'
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+xYbW/bNhD+K4E+Jw5JkXrxt2JJsRZLViTZumYohBNJ2UplSaCopE6R/z6SkmzZaRttK1p0q79YPB7J4z33wrsPHlcStBQJaG/uEYSjI0yOcHSF2ZyiOaHX3qGXN4mSulWlN9eqlYfeSjYNLGTjzf98a0aVkGaxlo02zFWt86o0Ux883iolS742k79dnpi5GtYrWWo7p9e1XXR5en5yeuE9HHoFpLJIhBHGm5dtURx69jsBcQslNzRkeJTMpN1xw9Jo0K05y2vLd2V1V5oztAL+Li8XCe/EimmIsB9EcRjRwNwvIthHvmFsa/G5mwf25ilovkxyMZzXjYdTx7ReJQORt42uVk2Sl1k10DJVrcx9hDKsVgV2Ww+ESiKS4lhwyAQmFGEeSZAZBkoRjVMqhNVqeiO5FfRZv/7wKeTw9dN3ZJanhNVW7GpVQ7neqldJqbFZi318cHkQ6eXBs1vpDTNksy7XFuUzKG/zougYHJLe+UszuM9r84miyGdHOMTMSl+1pVadaVjLWFaldDISygJsfoYoV5AXwxG7VsZBqVyqJAOeF+7wjsvoJhfGxHIoBmPNpJAKikTD+xGSTr492q1UeZZz2BiwkZva/6bl3IHW7SiVqlRv/EJqI2RvDA8PxkjzsmkVjIy0UkaA0TE1KC6LjQXUihcJQSKSUqZA0oBmPgKZ+lQiRrIUJIqjsQm86tY/aQH+BAtwPIUsF3o5iHeXi+1gKfPFUm8kV0aXWV6a/WrjZSN7v+v5MJqhXayMRurKaHshE+fi9t7bq3Qzv7iJw14fRZKFIgsClqZBkNKAZTEREMkoDakIfB/g6buzCXd3Hr4XZCx8Wi6UW5dVamVWltY0dwPUp07seIwRVkVrrcib+wgN5Ca/t0vp+2DD2UdBo1RoC70hZ3khh7l8ZRR0XJeLzWyrjBK9pdZ1Mz8+ltCsrYKP7KJm1vhHbXN0ZzR/RGawgvuqhLtmZhz72DEc74BxbO+BCY6OY4GYAAzmm9KI8hQiTMEXKYmJT2J/NpagFlknRQd+R7yvi8dEWRfkMdVK0nuMcVmjUetMvTvYYYIBGXlwxAWJKMpYyiWLsojRyJoC88fucGERedIg6ASDcDy7caaR6ja3luGdvq+HwNvFHhe6XtngpXqbwDPnqI/SnnIxIhnY6CxEW+oj7iJvdLK3paM94hSyyE3MWhujXG/S0Yg4SqVjYrJowQQoLaXRdwZFY0Oa2f+j2zXLvLY528UvM6oTBginMuUZ9n2KfD8VKE4ZwigMM5mJcBSdgbsw363lkKx0yvDvEpmgMEab+IgFMgwiTn2TrYM0JRD6AfUFIgxi9g3Qfp6rcZ55hLU/Y+hpqOmMsolI9xtOApp8QZTJ14HY7AEhYB7jzDix8ONAAg5ZhHEaEpnxbwDxK5VXyj4dPo1yMPPZ0ygH0/05mDE2FWX8BVHGXwflmDIeBygOEeUUQpYSQoFFgvIwBJ6ib4GyeyxdysKe+jmk2SSk2VR//jtIfx/+/NbVX20p9uqfhkPZP5V6glO2watTxY+8/n/K6139bbXY467Vu4QDJijybQIQVFqkOSWYAQUT/rMwGMN+1a/fR2xyXf+RnkBHSrpabWfmCesKppYRTb6wVVG63i+IutEeDFsA/w0MW0Pd6GZTjdrSNJNDh2bAbVBAX821aZHzvXLCbTUbigpXN4ib00D8/FL9Qc6XZ1cv7n49OfPfXD2/uT65KM5WF8vz12fo7OYUv7m6WJ69fuFf33DiLKH6aLfDN9Wtee1JnoaccswhZUFm8gVlMpY424kBk7sdZAJQZNvt8F5Wy/LgpHIBZuh5eD/1X+PGx7ODkzxzXSd9cFGBGPc+vPNK6eVd35GY3AL5dPeDuR/CcfwFuh990+kfdz9sL6Nt6ia5d8JhF9laVf5oYf3nW1hpu7ZR/ofzftfOa99ku6lg1Hl7Lu0t+x6T6791FFjZ29nbzkzOQa7IXYJa2DdFZzrdI3DzxrAVwMd37Zt7e/u6p8+kjd/2DcGJWXEjxGWfU72HvwAAAP//AwAi/QQo3xgAAA==
     http_version: 
-  recorded_at: Tue, 08 Dec 2015 23:07:06 GMT
-recorded_with: VCR 3.0.0
+  recorded_at: Tue, 18 Dec 2018 15:40:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/easypost/shipment_spec.rb
+++ b/spec/easypost/shipment_spec.rb
@@ -15,7 +15,7 @@ module Spree
         lastname: 'Scamander',
         address1: '200 19th St',
         city: 'Birmingham',
-        state: FactoryBot.create(:state),
+        state: Spree::State.first,
         country: FactoryBot.create(:country),
         zipcode: 35203,
         phone: '123456789'

--- a/spec/easypost/shipment_spec.rb
+++ b/spec/easypost/shipment_spec.rb
@@ -15,8 +15,8 @@ module Spree
         lastname: 'Scamander',
         address1: '200 19th St',
         city: 'Birmingham',
-        state: FactoryGirl.create(:state),
-        country: FactoryGirl.create(:country),
+        state: FactoryBot.create(:state),
+        country: FactoryBot.create(:country),
         zipcode: 35203,
         phone: '123456789'
        )

--- a/spec/easypost/stock_estimator_decorator_spec.rb
+++ b/spec/easypost/stock_estimator_decorator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Spree::Stock::Estimator, :vcr do
         end
 
         context 'shipping methods are not front end visible' do
-          before { Spree::ShippingMethod.all.each{|x| x.update!(display_on: 'back_end') } }
+          before { Spree::ShippingMethod.find_each { |x| x.update!(available_to_users: false) } }
           it { is_expected.to be_empty }
         end
       end

--- a/spec/factories/spree_modification.rb
+++ b/spec/factories/spree_modification.rb
@@ -1,4 +1,4 @@
-FactoryGirl.modify do
+FactoryBot.modify do
   factory :shipping_method do
     admin_name 'Stuff'
     display_on 'front_end'

--- a/spec/factories/spree_modification.rb
+++ b/spec/factories/spree_modification.rb
@@ -1,7 +1,7 @@
 FactoryBot.modify do
   factory :shipping_method do
     admin_name 'Stuff'
-    display_on 'front_end'
+    available_to_users true
   end
 
   factory :stock_location do

--- a/spec/factories/spree_modification.rb
+++ b/spec/factories/spree_modification.rb
@@ -1,20 +1,20 @@
 FactoryBot.modify do
   factory :shipping_method do
-    admin_name 'Stuff'
-    available_to_users true
+    admin_name { 'Stuff' }
+    available_to_users { true }
   end
 
   factory :stock_location do
-    address1 '131 S 8th Ave'
-    city 'Manville'
+    address1 { '131 S 8th Ave' }
+    city { 'Manville' }
     association(:state, name: 'New Jersey', abbr: 'NJ')
-    zipcode '08835'
+    zipcode { '08835' }
   end
 
   factory :address do
-    address1 '215 N 7th Ave'
-    city 'Manville'
+    address1 { '215 N 7th Ave' }
+    city { 'Manville' }
     association(:state, name: 'New Jersey', abbr: 'NJ')
-    zipcode '08835'
+    zipcode { '08835' }
   end
 end

--- a/spec/helpers/shipping_method_helpers.rb
+++ b/spec/helpers/shipping_method_helpers.rb
@@ -2,25 +2,25 @@ module ShippingMethodHelpers
   FIXTURE_PARAMS = [
     {
       name:       "USPS First",
-      display_on: :both,
+      available_to_users: true,
       admin_name: "USPS First",
       code:       "First"
     },
     {
       name:       "USPS Priority",
-      display_on: :both,
+      available_to_users: true,
       admin_name: "USPS Priority",
       code:       "Priority"
     },
     {
       name:       "USPS ParcelSelect",
-      display_on: :both,
+      available_to_users: true,
       admin_name: "USPS ParcelSelect",
       code:       "ParcelSelect"
     },
     {
       name:       "USPS Express",
-      display_on: :both,
+      available_to_users: true,
       admin_name: "USPS Express",
       code:       "Express"
     }

--- a/spec/models/spree_easypost/return_authorization_spec.rb
+++ b/spec/models/spree_easypost/return_authorization_spec.rb
@@ -23,17 +23,17 @@ RSpec.describe Spree::EasyPost::ReturnAuthorization, :vcr do
     it { is_expected.to be_a EasyPost::PostageLabel }
     it 'has the correct fields' do
       expect(subject).to have_attributes(
-         id: "pl_b0e149176a7b4313bb1d982705e71da6",
+         id: "pl_f7df665bb66b465f92da8e8b74d633aa",
          object: "PostageLabel",
-         created_at: "2015-12-08T23:07:02Z",
-         updated_at: "2015-12-08T23:07:02Z",
+         created_at: "2018-12-18T15:40:25Z",
+         updated_at: "2018-12-18T15:40:26Z",
          date_advance: 0,
          integrated_form: "none",
-         label_date: "2015-12-08T23:07:00Z",
+         label_date: "2018-12-18T15:40:25Z",
          label_resolution: 300,
          label_size: "4x6",
          label_type: "default",
-         label_url: "http://assets.geteasypost.com/postage_labels/labels/20151208/c2e6cfedd0744e598ae2d9266f97aaed.png",
+         label_url: "https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20181218/9d05da1a2184484cba814a3db2923293.png",
          label_file_type: "image/png"
       )
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ VCR.configure do |config|
 end
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # == URL Helpers
   #


### PR DESCRIPTION
This PR aims to get the Travis build green by doing the following:

* Lock FactoryBot to v4.10 for Solidus versions lower than v2.5
* Add `deface` as dependency for Solidus versions lower than v2.5
* Use `Spree::State.first` instead of `FactoryBot.create(:state)`
* Update cassettes with latest EasyPost API payload

Besides that, several deprecation warnings were fixed and various hacks were removed :tada: