### PR TITLE
Lock SQLite3 to version 1.3

### DIFF
--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'


### PR DESCRIPTION
SQLite3 v1.4 was released on February 4th, which breaks compatibility with ActiveRecord's adapter for said DB engine.