### PR TITLE
Add Rubocop for linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,319 @@
+# Relaxed.Ruby.Style
+
+AllCops:
+  Exclude:
+    - 'spec/dummy/**/*'
+    - 'bin/**'
+  TargetRubyVersion: 2.2
+
+# Sometimes I believe this reads better
+# This also causes spacing issues on multi-line fixes
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+# We use class vars and will have to continue doing so for compatability
+Style/ClassVars:
+  Enabled: false
+
+# We need these names for backwards compatability
+Naming/PredicateName:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+# This has been used for customization
+Style/MutableConstant:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Performance/Count:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+
+# We can use good judgement here
+Style/RegexpLiteral:
+  Enabled: false
+
+# Unicode comments are useful
+Style/AsciiComments:
+  Enabled: false
+
+Layout/EndAlignment:
+  Enabled: false
+
+Layout/ElseAlignment:
+  Enabled: false
+
+Layout/IndentationWidth:
+  Enabled: false
+
+Layout/AlignParameters:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/IndentArray:
+  Enabled: false
+
+Layout/IndentHash:
+  Enabled: false
+
+Layout/AlignHash:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+# Symbol Arrays are ok and the %i syntax widely unknown
+Style/SymbolArray:
+  Enabled: false
+
+Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_param
+    - find_by_param!
+
+# We use a lot of
+#
+#     expect {
+#       something
+#     }.to { happen }
+#
+# syntax in the specs files.
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - '*/spec/**/*'
+    - 'spec/**/*' # For the benefit of apps that inherit from this config
+
+# We use eval to add common_spree_dependencies into the Gemfiles of each of our gems
+Security/Eval:
+  Exclude:
+    - 'Gemfile'
+    - 'common_spree_dependencies.rb'
+    - '*/Gemfile'
+
+Naming/VariableNumber:
+  Enabled: false
+
+# Write empty methods as you wish.
+Style/EmptyMethod:
+  Enabled: false
+
+# From http://relaxed.ruby.style/
+
+Style/Alias:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylealias
+
+Style/BeginBlock:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylebeginblock
+
+Style/BlockDelimiters:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleblockdelimiters
+
+Style/Documentation:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledocumentation
+
+Layout/DotPosition:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledotposition
+
+Style/DoubleNegation:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledoublenegation
+
+Style/EndBlock:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleendblock
+
+Style/FormatString:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleformatstring
+
+Style/IfUnlessModifier:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleifunlessmodifier
+
+Style/Lambda:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylelambda
+
+Style/ModuleFunction:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylemodulefunction
+
+Style/MultilineBlockChain:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylemultilineblockchain
+
+Style/NegatedIf:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylenegatedif
+
+Style/NegatedWhile:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylenegatedwhile
+
+Style/ParallelAssignment:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleparallelassignment
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylepercentliteraldelimiters
+
+Style/PerlBackrefs:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleperlbackrefs
+
+Style/Semicolon:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesemicolon
+
+Style/SignalException:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesignalexception
+
+Style/SingleLineBlockParams:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesinglelineblockparams
+
+Style/SingleLineMethods:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesinglelinemethods
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespacebeforeblockbraces
+
+Layout/SpaceInsideParens:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespaceinsideparens
+
+Style/SpecialGlobalVars:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespecialglobalvars
+
+Style/StringLiterals:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylestringliterals
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylewhileuntilmodifier
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#lintambiguousregexpliteral
+
+Lint/AssignmentInCondition:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#lintassignmentincondition
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+# json.() is idiomatic in jbuilder files
+Style/LambdaCall:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+    - id
+    - to
+    - _
+
+# Rubocop doesn't understand side-effects
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Lint/UselessComparison:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,7 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', git: 'https://github.com/solidusio/solidus.git', branch: branch
 gem 'solidus_auth_devise'
 
-if branch < 'v2.5'
-  gem 'factory_bot', '4.10.0'
-else
-  gem 'factory_bot', '> 4.10.0'
-end
+gem 'factory_bot', (branch < 'v2.5' ? '4.10.0' : '> 4.10.0')
 
 if ENV['DB'] == 'mysql'
   gem 'mysql2', '~> 0.4.10'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/app/models/solidus_easypost/estimator.rb
+++ b/app/models/solidus_easypost/estimator.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module SolidusEasypost
   class Estimator
-    def shipping_rates(package, frontend_only = true)
+    def shipping_rates(package, _frontend_only = true)
       shipment = package.easypost_shipment
       rates = shipment.rates.sort_by { |r| r.rate.to_i }
 
@@ -9,7 +11,7 @@ module SolidusEasypost
       if rates.any?
         rates.each do |rate|
           spree_rate = Spree::ShippingRate.new(
-            name: "#{ rate.carrier } #{ rate.service }",
+            name: "#{rate.carrier} #{rate.service}",
             cost: rate.rate,
             easy_post_shipment_id: rate.shipment_id,
             easy_post_rate_id: rate.id,
@@ -36,7 +38,7 @@ module SolidusEasypost
     # Shipping method based on the admin(internal)_name. This is not user facing
     # and should not be changed in the admin.
     def find_or_create_shipping_method(rate)
-      method_name = "#{ rate.carrier } #{ rate.service }"
+      method_name = "#{rate.carrier} #{rate.service}"
       Spree::ShippingMethod.find_or_create_by(admin_name: method_name) do |r|
         r.name = method_name
         r.available_to_users = false

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   module EasyPost
     module AddressDecorator

--- a/app/models/spree/package_decorator.rb
+++ b/app/models/spree/package_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   module Stock
     module PackageDecorator

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -37,8 +37,8 @@ module Spree
     end
 
     def buy_easypost_rate
-      rate = easypost_shipment.rates.find do |rate|
-        rate.id == selected_easy_post_rate_id
+      rate = easypost_shipment.rates.find do |sr|
+        sr.id == selected_easy_post_rate_id
       end
 
       easypost_shipment.buy(rate)

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   module ShipmentDecorator
     def self.prepended(mod)

--- a/app/models/spree/shipping_rate_decorator.rb
+++ b/app/models/spree/shipping_rate_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   module ShippingRateDecorator
     def name

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   module Stock
     module EstimatorDecorator

--- a/app/models/spree_easypost/return_authorization.rb
+++ b/app/models/spree_easypost/return_authorization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Spree

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Spree::Core::Engine.routes.draw do
   # Add your extension routes here
 end

--- a/db/migrate/20140515024440_add_easy_post_fields_to_shipping_rate.rb
+++ b/db/migrate/20140515024440_add_easy_post_fields_to_shipping_rate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddEasyPostFieldsToShippingRate < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_shipping_rates, :name, :string

--- a/lib/solidus_easypost.rb
+++ b/lib/solidus_easypost.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'solidus_support'
 require 'solidus_core'
 

--- a/lib/solidus_easypost/engine.rb
+++ b/lib/solidus_easypost/engine.rb
@@ -22,7 +22,7 @@ module Solidus
         end
       end
 
-      config.to_prepare &method(:activate).to_proc
+      config.to_prepare(&method(:activate).to_proc)
     end
   end
 end

--- a/lib/solidus_easypost/engine.rb
+++ b/lib/solidus_easypost/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Solidus
   module EasyPost
     class Engine < Rails::Engine

--- a/lib/solidus_easypost/factories.rb
+++ b/lib/solidus_easypost/factories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
   #

--- a/lib/solidus_easypost/version.rb
+++ b/lib/solidus_easypost/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Solidus
   module EasyPost
     VERSION = "2.0".freeze

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 require_relative 'lib/solidus_easypost/version'
 
@@ -14,26 +14,26 @@ Gem::Specification.new do |s|
   s.email     = 'brendan@stembolt.com'
   s.homepage  = 'https://github.com/solidusio-contrib/solidus_easypost'
 
-  #s.files       = `git ls-files`.split("\n")
-  #s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
+  # s.files       = `git ls-files`.split("\n")
+  # s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_path = 'lib'
   s.requirements << 'none'
 
+  s.add_dependency "deface", '~> 1.0'
+  s.add_dependency 'easypost'
   s.add_dependency 'solidus', ['>= 1.1', '< 3.x']
   s.add_dependency 'solidus_support', '>= 0.1.1'
-  s.add_dependency 'easypost'
-  s.add_dependency "deface", '~> 1.0'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'ffaker'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3', '~> 1.3.6'
-  s.add_development_dependency 'pry'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
 end

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version     = Solidus::EasyPost::VERSION
   s.summary     = 'Easy post integration for Solidus'
   s.description = 'Easy post integration for Solidus'
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = '>= 2.2'
 
   s.author    = 'Brendan Deere'
   s.email     = 'brendan@stembolt.com'

--- a/spec/decorators/package_decorator_spec.rb
+++ b/spec/decorators/package_decorator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Spree::Stock::Package, :vcr do

--- a/spec/decorators/shipment_decorator_spec.rb
+++ b/spec/decorators/shipment_decorator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Spree::Shipment, :vcr do

--- a/spec/easypost/address_decorator_spec.rb
+++ b/spec/easypost/address_decorator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Spree::Address, :vcr do

--- a/spec/easypost/rate_fetcher_spec.rb
+++ b/spec/easypost/rate_fetcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Spree::Stock::Estimator customizations', :vcr do

--- a/spec/easypost/shipment_spec.rb
+++ b/spec/easypost/shipment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Spree

--- a/spec/easypost/shipping_rate_decorator_spec.rb
+++ b/spec/easypost/shipping_rate_decorator_spec.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Spree::ShippingRate, :vcr do
   let(:rate) { described_class.new name: name }
   let(:name) { 'SuperAwesomeCool' }
-
 
   describe '#name' do
     subject { rate.name }

--- a/spec/easypost/stock_estimator_decorator_spec.rb
+++ b/spec/easypost/stock_estimator_decorator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Spree::Stock::Estimator, :vcr do

--- a/spec/factories/spree_modification.rb
+++ b/spec/factories/spree_modification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.modify do
   factory :shipping_method do
     admin_name { 'Stuff' }

--- a/spec/helpers/shipping_method_helpers.rb
+++ b/spec/helpers/shipping_method_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ShippingMethodHelpers
   FIXTURE_PARAMS = [
     {
@@ -29,10 +31,8 @@ module ShippingMethodHelpers
   def create_shipping_methods
     shipping_category = create :shipping_category
     FIXTURE_PARAMS.each do |params|
-      params.merge!(
-        calculator: Spree::Calculator::Shipping::FlatRate.new,
-        shipping_categories: [shipping_category]
-      )
+      params[:calculator] = Spree::Calculator::Shipping::FlatRate.new
+      params[:shipping_categories] = [shipping_category]
       Spree::ShippingMethod.create! params
     end
   end

--- a/spec/models/spree_easypost/return_authorization_spec.rb
+++ b/spec/models/spree_easypost/return_authorization_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Spree::EasyPost::ReturnAuthorization, :vcr do
   let(:auth) { described_class.new return_authorization }
   let(:return_authorization) do
-    create :return_authorization  do |ra|
+    create :return_authorization do |ra|
       ra.return_items << create(:return_item)
     end
   end
@@ -23,18 +25,18 @@ RSpec.describe Spree::EasyPost::ReturnAuthorization, :vcr do
     it { is_expected.to be_a EasyPost::PostageLabel }
     it 'has the correct fields' do
       expect(subject).to have_attributes(
-         id: "pl_f7df665bb66b465f92da8e8b74d633aa",
-         object: "PostageLabel",
-         created_at: "2018-12-18T15:40:25Z",
-         updated_at: "2018-12-18T15:40:26Z",
-         date_advance: 0,
-         integrated_form: "none",
-         label_date: "2018-12-18T15:40:25Z",
-         label_resolution: 300,
-         label_size: "4x6",
-         label_type: "default",
-         label_url: "https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20181218/9d05da1a2184484cba814a3db2923293.png",
-         label_file_type: "image/png"
+        id: "pl_f7df665bb66b465f92da8e8b74d633aa",
+        object: "PostageLabel",
+        created_at: "2018-12-18T15:40:25Z",
+        updated_at: "2018-12-18T15:40:26Z",
+        date_advance: 0,
+        integrated_form: "none",
+        label_date: "2018-12-18T15:40:25Z",
+        label_resolution: 300,
+        label_size: "4x6",
+        label_type: "default",
+        label_url: "https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20181218/9d05da1a2184484cba814a3db2923293.png",
+        label_file_type: "image/png"
       )
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Run Coverage report
 require 'pry'
 require 'simplecov'
@@ -14,7 +16,7 @@ end
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 
-require File.expand_path('../dummy/config/environment.rb',  __FILE__)
+require File.expand_path('dummy/config/environment.rb', __dir__)
 
 require 'rspec/rails'
 require 'database_cleaner'


### PR DESCRIPTION
In an effort to improve tooling and to achieve a more consistent development environment, this PR aims to include Rubocop to this gem, as well as fix all the offenses based on the [Rubocop config file](https://github.com/solidusio/solidus/blob/master/.rubocop.yml) that Solidus uses.