### PR TITLE
Use different easypost_address for the stock locations

### DIFF
--- a/app/decorators/models/solidus_easypost/spree/stock_location_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/stock_location_decorator.rb
@@ -3,25 +3,25 @@
 module SolidusEasypost
   module Spree
     module EasyPost
-      module AddressDecorator
+      module StockLocationDecorator
         def easypost_address
           attributes = {
             street1: address1,
             street2: address2,
             city: city,
             zip: zipcode,
-            phone: phone
+            phone: phone,
+            name: name,
+            company: name
           }
 
-          attributes[:company] = company if respond_to?(:company)
-          attributes[:name] = full_name if respond_to?(:full_name)
           attributes[:state] = state ? state.abbr : state_name
           attributes[:country] = country&.iso
 
           ::EasyPost::Address.create attributes
         end
 
-        ::Spree::Address.prepend self
+        ::Spree::StockLocation.prepend self
       end
     end
   end

--- a/spec/cassettes/Spree_StockLocation/_easypost_address/has_the_correct_attributes.yml
+++ b/spec/cassettes/Spree_StockLocation/_easypost_address/has_the_correct_attributes.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[name]=NY%20Warehouse&address[company]=NY%20Warehouse&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.0.1
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '209'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 3acadbc45d889df9f9b5c7f80003e329
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_e0551b241fb74374b5fbdca643126916"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.039624'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb4sj
+      X-Version-Label:
+      - easypost-201909212308-99b9bdfb98-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1wdc ff5a2958df
+      - intlb1sj ff5a2958df
+      - intlb2wdc ff5a2958df
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"adr_e0551b241fb74374b5fbdca643126916","object":"Address","created_at":"2019-09-23T10:27:05Z","updated_at":"2019-09-23T10:27:05Z","name":"NY
+        Warehouse","company":"NY Warehouse","street1":"131 S 8th Ave","street2":null,"city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"2024561111","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+    http_version: 
+  recorded_at: Mon, 23 Sep 2019 10:27:05 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/Spree_StockLocation/_easypost_address/is_an_EasyPost_Address_object.yml
+++ b/spec/cassettes/Spree_StockLocation/_easypost_address/is_an_EasyPost_Address_object.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: address[street1]=131%20S%208th%20Ave&address[city]=Manville&address[zip]=08835&address[phone]=(202)%20456-1111&address[name]=NY%20Warehouse&address[company]=NY%20Warehouse&address[state]=NJ&address[country]=US
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.0.1
+      Authorization:
+      - Bearer CvzYtuda6KRI9JjG7SAHbA
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '209'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - api.easypost.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 5d08c2c65d889dfaf9b5c7f9000444c2
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_07e0c99324334cdf93474b168497ec51"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.094700'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb9sj
+      X-Version-Label:
+      - easypost-201909212308-99b9bdfb98-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2wdc ff5a2958df
+      - intlb1wdc ff5a2958df
+      - intlb2sj ff5a2958df
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"adr_07e0c99324334cdf93474b168497ec51","object":"Address","created_at":"2019-09-23T10:27:06Z","updated_at":"2019-09-23T10:27:06Z","name":"NY
+        Warehouse","company":"NY Warehouse","street1":"131 S 8th Ave","street2":null,"city":"Manville","state":"NJ","zip":"08835","country":"US","phone":"2024561111","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+    http_version: 
+  recorded_at: Mon, 23 Sep 2019 10:27:06 GMT
+recorded_with: VCR 5.0.0

--- a/spec/easypost/stock_location_decorator_spec.rb
+++ b/spec/easypost/stock_location_decorator_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::StockLocation, :vcr do
+  let(:stock_location) { create :stock_location }
+
+  describe '#easypost_address' do
+    subject { stock_location.easypost_address }
+
+    it 'is an EasyPost::Address object' do
+      expect(subject).to be_a(EasyPost::Address)
+    end
+
+    it 'has the correct attributes' do
+      # combination of original address factory from easy post
+      # and the spree_modification factories
+      is_expected.to have_attributes(
+        name: 'NY Warehouse',
+        company: 'NY Warehouse',
+        street1: '131 S 8th Ave',
+        street2: nil,
+        city: 'Manville',
+        state: 'NJ',
+        zip: '08835',
+        country: 'US',
+        phone: '2024561111'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Ref: #41 

The stock location doesn't have the `company` attribute which is mandatory for some carrier like UPS.