### PR TITLE
Fix deprecation warning in engine.rb

### DIFF
--- a/lib/solidus_easypost/engine.rb
+++ b/lib/solidus_easypost/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusEasypost
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace Spree
 


### PR DESCRIPTION
Running the current `master` on Rails 5.2 / Solidus 2.10 results in the following warning:

```
DEPRECATION WARNING: SolidusSupport::EngineExtensions::Decorators is deprecated!
Use SolidusSupport::EngineExtensions instead. (called from <class:Engine> at
gems/solidus_easypost-eaa59ab84d89/lib/solidus_easypost/engine.rb:7)
```