### PR TITLE
Only use EasyPost when the item has a ShippingCategory that uses EasyPost

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This is an extension to integrate EasyPost with Solidus.
 
-Due to how it works, you will not be able to use any other extension for shipping methods. Your own
-shipping methods will not work, either. But the good thing is that you won't have to worry about
-that, because EasyPost handles it all for you.
+Due to how it works, you will not be able to use any other extension for shipping methods. But the good thing is that you won't have to worry about that, because EasyPost handles it all for you.
+
+However, it is possible to use your own shipping methods alongside EasyPost by defining Solidus ShippingCategories that operate independently of EasyPost. By default, EasyPost will handle shipping for all ShippingCategories, but if you don't want that, you can simply set `ShippingCategory#use_easypost?` to `false`.
 
 You will need to [sign up for an account](https://www.easypost.com/) to use this extension.
 

--- a/app/decorators/models/solidus_easypost/spree/stock/estimator_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/stock/estimator_decorator.rb
@@ -5,7 +5,11 @@ module SolidusEasypost
     module Stock
       module EstimatorDecorator
         def shipping_rates(package, frontend_only = true)
-          SolidusEasypost::Estimator.new.shipping_rates(package, frontend_only)
+          if package.shipping_categories.pluck(:use_easypost).any?
+            SolidusEasypost::Estimator.new.shipping_rates(package, frontend_only)
+          else
+            super
+          end
         end
 
         ::Spree::Stock::Estimator.prepend self

--- a/db/migrate/20200802032320_add_use_easypost_boolean_to_shipping_categories.rb
+++ b/db/migrate/20200802032320_add_use_easypost_boolean_to_shipping_categories.rb
@@ -1,0 +1,5 @@
+class AddUseEasypostBooleanToShippingCategories < SolidusSupport::Migration[5.1]
+  def change
+    add_column :spree_shipping_categories, :use_easypost, :boolean, default: true
+  end
+end


### PR DESCRIPTION
This is an attempt to address some of the functionality desired by https://github.com/solidusio-contrib/solidus_easypost/issues/47.

Here is one way that a store (like ours, which offers subscription products and digital products that don’t ship normally and have very specific custom shipping rates) can use SolidusEasypost along more custom functionality.

It adds a `use_easypost` boolean to each Shipping Category (true by default). Then there is a check to see if a package belongs to any shipping categories that use EasyPost. If so, it overrides the estimator shipping rates as normal for solidus_easypost. If not, it falls back to the default Solidus behavior for those shipping categories.

Something like this would be terrific for a store like ours, and would be the start of the work described in https://github.com/solidusio-contrib/solidus_easypost/issues/47.

@vassalloandrea what do you think?