### PR TITLE
Allow tracking packages via EasyPost

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ SolidusEasypost.configure do |config|
 end
 ```
 
+### Getting tracking updates via webhooks
+
+Once a tracker has been created for a given carton, you can either use it manually or you can use
+EasyPost's [webhooks](https://www.easypost.com/docs/api#webhooks) to have any shipping updates
+forwarded to your application.
+
+In order for webhooks to work, you need to install the [solidus_webhooks](https://github.com/solidusio-contrib/solidus_webhooks)
+extension. When the extension is available, a webhook will be automatically configured at
+`/webhooks/easypost_trackers`. Simply add it to your EasyPost dashboard with the following
+configuration:
+
+- *Environment:* `Production` or `Test`
+- *Webhook URL:* `https://your-store.com/webhooks/easypost_trackers?token=[YOUR_TOKEN]` (replace
+  `[YOUR_TOKEN]` with the API key of an admin user or, better yet, a 
+  [webhook user](https://github.com/solidusio-contrib/solidus_webhooks#restricting-permissions)
+
+Now, when Solidus gets a tracking update from EasyPost, a `solidus_easypost.tracker.updated` event
+will be fired. The event's payload will contain the `:carton` and `:payload` keys, with the
+`Spree::Carton` object associated to the tracker and the EasyPost payload respectively.
+
 ## Development
 
 ### Testing the extension

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ retrieve the tracker in the future.
 > The extension already generates compliant shipping methods by default, but you may need to change
 > the data on your custom shipping methods if you want to track them. 
 
+You can also enable automatic tracking for all created cartons:
+
+```ruby
+SolidusEasypost.configure do |config|
+  config.track_all_cartons = true
+end
+```
+
 ## Development
 
 ### Testing the extension

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ enabled before they are visible and selectable in the storefront during the chec
 
 If you want to override this logic, you can provide your own `shipping_method_selector_class`.
 
+### Tracking cartons via EasyPost
+
+You can optionally track packages via EasyPost's [Trackers API](https://www.easypost.com/docs/api#trackers).
+In order to do this, you can call the `#easypost_tracker` method on any carton:
+
+```ruby
+carton = Spree::Carton.find(2)
+carton.easypost_tracker # => #<Easypost::Tracker>
+```
+
+This will also save the ID of the tracker on the `easy_post_tracker_id` column, to more easily
+retrieve the tracker in the future.
+
+> NOTE: In orders for carton tracking to work, you need to make sure that the `tracking` column
+> in `spree_cartons` contains a valid tracking number, and that the `carrier` column in
+> `spree_shipping_methods` contains a carrier name [that EasyPost will recognize](https://www.easypost.com/docs/api#carrier-tracking-strings).
+> The extension already generates compliant shipping methods by default, but you may need to change
+> the data on your custom shipping methods if you want to track them. 
+
 ## Development
 
 ### Testing the extension

--- a/app/decorators/models/solidus_easypost/spree/carton_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/carton_decorator.rb
@@ -3,6 +3,10 @@
 module SolidusEasypost
   module Spree
     module CartonDecorator
+      def self.prepended(base)
+        base.after_create :track_via_easypost
+      end
+
       def easypost_tracker
         return @easypost_tracker if @easypost_tracker
 
@@ -18,6 +22,14 @@ module SolidusEasypost
         end
 
         @easypost_tracker
+      end
+
+      private
+
+      def track_via_easypost
+        return unless SolidusEasypost.configuration.track_all_cartons
+
+        easypost_tracker
       end
 
       ::Spree::Carton.prepend self

--- a/app/decorators/models/solidus_easypost/spree/carton_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/carton_decorator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  module Spree
+    module CartonDecorator
+      def easypost_tracker
+        return @easypost_tracker if @easypost_tracker
+
+        if easy_post_tracker_id.present?
+          @easypost_tracker = EasyPost::Tracker.retrieve(easy_post_tracker_id)
+        else
+          @easypost_tracker = EasyPost::Tracker.create(
+            tracking_code: tracking,
+            carrier: shipping_method.carrier,
+          )
+
+          update!(easy_post_tracker_id: @easypost_tracker.id)
+        end
+
+        @easypost_tracker
+      end
+
+      ::Spree::Carton.prepend self
+    end
+  end
+end

--- a/config/initializers/webhooks.rb
+++ b/config/initializers/webhooks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+if defined?(SolidusWebhooks)
+  SolidusWebhooks.register_webhook :easypost_trackers, ->(payload) do
+    SolidusEasypost::TrackerWebhookHandler.call(payload)
+  end
+end

--- a/db/migrate/20201025110912_add_tracker_id_to_cartons.rb
+++ b/db/migrate/20201025110912_add_tracker_id_to_cartons.rb
@@ -1,0 +1,6 @@
+class AddTrackerIdToCartons < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_cartons, :easy_post_tracker_id, :string
+    add_index :spree_cartons, :easy_post_tracker_id
+  end
+end

--- a/lib/generators/solidus_easypost/install/templates/initializer.rb
+++ b/lib/generators/solidus_easypost/install/templates/initializer.rb
@@ -6,6 +6,9 @@ SolidusEasypost.configure do |config|
   # Purchase labels from EasyPost when shipping shipments in Solidus?
   # config.purchase_labels = true
 
+  # Create a tracker in EasyPost and receive webhooks for all cartons?
+  # config.track_all_cartons = false
+
   # A class that responds to `#compute`, accepting an `EasyPost::Rate`
   # instance and returning the cost for that rate.
   # config.shipping_rate_calculator_class = 'SolidusEasypost::ShippingRateCalculator'

--- a/lib/solidus_easypost.rb
+++ b/lib/solidus_easypost.rb
@@ -14,6 +14,7 @@ require 'solidus_easypost/shipment_builder'
 require 'solidus_easypost/estimator'
 require 'solidus_easypost/shipping_rate_calculator'
 require 'solidus_easypost/shipping_method_selector'
+require 'solidus_easypost/tracker_webhook_handler'
 
 module SolidusEasypost
   class << self

--- a/lib/solidus_easypost/configuration.rb
+++ b/lib/solidus_easypost/configuration.rb
@@ -2,11 +2,12 @@
 
 module SolidusEasypost
   class Configuration
-    attr_accessor :purchase_labels
+    attr_accessor :purchase_labels, :track_all_cartons
     attr_writer :shipping_rate_calculator_class, :shipping_method_selector_class
 
     def initialize
       self.purchase_labels = true
+      self.track_all_cartons = false
     end
 
     def shipping_rate_calculator_class

--- a/lib/solidus_easypost/shipping_method_selector.rb
+++ b/lib/solidus_easypost/shipping_method_selector.rb
@@ -3,14 +3,14 @@
 module SolidusEasypost
   class ShippingMethodSelector
     def shipping_method_for(rate)
-      name = "#{rate.carrier} #{rate.service}"
-
-      ::Spree::ShippingMethod.find_or_create_by(admin_name: name) do |shipping_method|
-        shipping_method.name = name
-        shipping_method.available_to_users = false
-        shipping_method.code = rate.service
+      ::Spree::ShippingMethod.find_or_create_by(
+        carrier: rate.carrier,
+        service_level: rate.service,
+      ) do |shipping_method|
+        shipping_method.name = "#{rate.carrier} #{rate.service}"
         shipping_method.calculator = ::Spree::Calculator::Shipping::FlatRate.create
         shipping_method.shipping_categories = [::Spree::ShippingCategory.first]
+        shipping_method.available_to_users = false
       end
     end
   end

--- a/lib/solidus_easypost/tracker_webhook_handler.rb
+++ b/lib/solidus_easypost/tracker_webhook_handler.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  class TrackerWebhookHandler
+    def self.call(payload)
+      return unless payload['description'] == 'tracker.updated'
+
+      carton = ::Spree::Carton.find_by(easy_post_tracker_id: payload['result']['id'])
+      return unless carton
+
+      ::Spree::Event.fire 'solidus_easypost.tracker.updated', carton: carton, payload: payload
+    end
+  end
+end

--- a/spec/models/spree/carton_spec.rb
+++ b/spec/models/spree/carton_spec.rb
@@ -1,4 +1,28 @@
 RSpec.describe Spree::Carton do
+  describe '.create' do
+    context 'when track_all_cartons is true' do
+      it 'tracks the package automatically' do
+        stub_easypost_config(track_all_cartons: true)
+        tracker = instance_double(EasyPost::Tracker, id: 'trk_test')
+        allow(EasyPost::Tracker).to receive(:create).and_return(tracker)
+
+        carton = create(:carton)
+
+        expect(carton.easy_post_tracker_id).to eq('trk_test')
+      end
+    end
+
+    context 'when track_all_cartons is false' do
+      it 'does not track all packages automatically' do
+        stub_easypost_config(track_all_cartons: false)
+
+        carton = create(:carton)
+
+        expect(carton.easy_post_tracker_id).to eq(nil)
+      end
+    end
+  end
+
   describe '#easypost_tracker' do
     context 'when a tracker was already created' do
       it 'returns the existing tracker' do

--- a/spec/models/spree/carton_spec.rb
+++ b/spec/models/spree/carton_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Spree::Carton do
+  describe '#easypost_tracker' do
+    context 'when a tracker was already created' do
+      it 'returns the existing tracker' do
+        carton = create(:carton, easy_post_tracker_id: 'trk_test')
+        tracker = instance_double(EasyPost::Tracker)
+        allow(EasyPost::Tracker).to receive(:retrieve).with('trk_test').and_return(tracker)
+
+        expect(carton.easypost_tracker).to eq(tracker)
+      end
+    end
+
+    context 'when a tracker was not created' do
+      it 'creates a new tracker' do
+        carton = create(:carton, tracking: 'TESTTRACKING', shipping_method: create(:shipping_method, carrier: 'FedEx'))
+        tracker = instance_double(EasyPost::Tracker, id: 'trk_test')
+        allow(EasyPost::Tracker).to receive(:create).with(tracking_code: 'TESTTRACKING', carrier: 'FedEx').and_return(tracker)
+
+        expect(carton.easypost_tracker).to eq(tracker)
+      end
+
+      it "sets the tracker's ID on the carton" do
+        carton = create(:carton)
+        tracker = instance_double(EasyPost::Tracker, id: 'trk_test')
+        allow(EasyPost::Tracker).to receive(:create).and_return(tracker)
+
+        carton.easypost_tracker
+
+        expect(carton.easy_post_tracker_id).to eq('trk_test')
+      end
+    end
+  end
+end

--- a/spec/solidus_easypost/shipping_method_selector_spec.rb
+++ b/spec/solidus_easypost/shipping_method_selector_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe SolidusEasypost::ShippingMethodSelector do
   describe '#shipping_method_for' do
     context 'when a shipping method for the given carrier and service exists' do
       it 'returns the existing shipping method' do
-        shipping_method = create(:shipping_method, admin_name: 'USPS Express')
+        shipping_method = create(:shipping_method, carrier: 'USPS', service_level: 'Express')
         easypost_rate = EasyPost::Rate.construct_from('carrier' => 'USPS', 'service' => 'Express')
 
         selector = described_class.new
@@ -21,11 +21,11 @@ RSpec.describe SolidusEasypost::ShippingMethodSelector do
         selected_shipping_method = selector.shipping_method_for(easypost_rate)
 
         expect(selected_shipping_method).to have_attributes(
-          admin_name: 'USPS Express',
           name: 'USPS Express',
-          available_to_users: false,
-          code: 'Express',
+          carrier: 'USPS',
+          service_level: 'Express',
           shipping_categories: [shipping_category],
+          available_to_users: false,
         )
       end
     end

--- a/spec/solidus_easypost/tracker_webhook_handler_spec.rb
+++ b/spec/solidus_easypost/tracker_webhook_handler_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe SolidusEasypost::TrackerWebhookHandler do
+  describe '.call' do
+    context 'when the event is not tracker.updated' do
+      it 'does not process the event' do
+        stub_const('Spree::Event', class_spy(Spree::Event))
+        create(:carton, easy_post_tracker_id: 'trk_test')
+
+        payload = {
+          'description' => 'tracker.created',
+          'result' => {
+            'id' => 'trk_test',
+          },
+        }
+        described_class.call(payload)
+
+        expect(Spree::Event).not_to have_received(:fire)
+      end
+    end
+
+    context 'when the tracker was not registered in Solidus' do
+      it 'does not process the event' do
+        stub_const('Spree::Event', class_spy(Spree::Event))
+        create(:carton, easy_post_tracker_id: 'trk_test')
+
+        payload = {
+          'description' => 'tracker.updated',
+          'result' => {
+            'id' => 'trk_test1',
+          },
+        }
+        described_class.call(payload)
+
+        expect(Spree::Event).not_to have_received(:fire)
+      end
+    end
+
+    context 'when the event is a tracker update for a registered tracker' do
+      it 'forwards the event via the event bus' do
+        stub_const('Spree::Event', class_spy(Spree::Event))
+        carton = create(:carton, easy_post_tracker_id: 'trk_test')
+
+        payload = {
+          'description' => 'tracker.updated',
+          'result' => {
+            'id' => 'trk_test',
+          },
+        }
+        described_class.call(payload)
+
+        expect(Spree::Event).to have_received(:fire).with(
+          'solidus_easypost.tracker.updated',
+          carton: carton,
+          payload: payload,
+        )
+      end
+    end
+  end
+end

--- a/spec/support/helpers/shipping_methods.rb
+++ b/spec/support/helpers/shipping_methods.rb
@@ -3,12 +3,18 @@ module SolidusEasypost
     module ShippingMethods
       def create_easypost_shipping_methods
         [
-          "USPS Express",
-          "USPS First",
-          "USPS ParcelSelect",
-          "USPS Priority",
-        ].each do |name|
-          create(:shipping_method, admin_name: name, available_to_users: true)
+          %w[USPS Express],
+          %w[USPS First],
+          %w[USPS ParcelSelect],
+          %w[USPS Priority],
+        ].each do |(carrier, service_level)|
+          create(
+            :shipping_method,
+            name: "#{carrier} #{service_level}",
+            carrier: carrier,
+            service_level: service_level,
+            available_to_users: true,
+          )
         end
       end
     end


### PR DESCRIPTION
Implements a way to track cartons via the EasyPost API, either manually or through webhooks.