### PR TITLE
Fix address name issue

### DIFF
--- a/lib/solidus_easypost/address_builder.rb
+++ b/lib/solidus_easypost/address_builder.rb
@@ -15,8 +15,10 @@ module SolidusEasypost
         attributes[:company] = address.company if address.respond_to?(:company)
         attributes[:name] = if address.respond_to?(:name)
                               address.name
-                            elsif respond_to?(:full_name)
+                            elsif address.respond_to?(:full_name)
                               address.full_name
+                            else
+                              [address.firstname, address.lastname].join(' ')
                             end
         attributes[:state] = address.state ? address.state.abbr : address.state_name
         attributes[:country] = address.country&.iso

--- a/spec/solidus_easypost/address_builder_spec.rb
+++ b/spec/solidus_easypost/address_builder_spec.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 RSpec.describe SolidusEasypost::AddressBuilder do
   describe '.from_address', vcr: { cassette_name: 'address_builder/from_address' } do
     it 'builds an address with the correct attributes' do
       address = described_class.from_address(build_stubbed(:address))
 
       expect(address).to have_attributes(object: 'Address')
+      expect(address.name).not_to be_nil
     end
   end
 


### PR DESCRIPTION
#### Information

- Fix issue related to empty `user/company` address

```
SHIPMENT.POSTAGE.FAILURE (422): FedEx returned error: RequestedShipment Recipient contact - companyName OR personName is required [] excluded from capture: Not configured to send/capture in environment 'development'
```