### PR TITLE
Allow to create a parcel passing other properties

### DIFF
--- a/lib/solidus_easypost/parcel_builder.rb
+++ b/lib/solidus_easypost/parcel_builder.rb
@@ -4,16 +4,43 @@ module SolidusEasypost
   class ParcelBuilder
     class << self
       def from_package(package)
-        total_weight = package.contents.sum do |item|
-          item.quantity * item.variant.weight
-        end
+        params = {
+          weight: package_property_total(property: :weight, package: package)
+        }
 
-        ::EasyPost::Parcel.create weight: total_weight
+        total_width = package_property_total(property: :width, package: package)
+        total_height = package_property_total(property: :height, package: package)
+        total_depth = package_property_total(property: :depth, package: package)
+
+        params[:width] = total_width unless total_width.zero?
+        params[:height] = total_height unless total_height.zero?
+        params[:length] = total_depth unless total_depth.zero?
+
+        ::EasyPost::Parcel.create(**params)
       end
 
       def from_return_authorization(return_authorization)
-        total_weight = return_authorization.inventory_units.joins(:variant).sum(:weight)
-        ::EasyPost::Parcel.create weight: total_weight
+        params = {
+          weight: return_authorization.inventory_units.joins(:variant).sum(:weight)
+        }
+
+        total_width = return_authorization.inventory_units.joins(:variant).sum(:width)
+        total_height = return_authorization.inventory_units.joins(:variant).sum(:height)
+        total_depth = return_authorization.inventory_units.joins(:variant).sum(:depth)
+
+        params[:width] = total_width unless total_width.zero?
+        params[:height] = total_height unless total_height.zero?
+        params[:length] = total_depth unless total_depth.zero?
+
+        ::EasyPost::Parcel.create(**params)
+      end
+
+      private
+
+      def package_property_total(property:, package:)
+        package.contents.sum do |item|
+          item.quantity * (item.variant.public_send(property) || 0)
+        end
       end
     end
   end

--- a/spec/solidus_easypost/parcel_builder_spec.rb
+++ b/spec/solidus_easypost/parcel_builder_spec.rb
@@ -1,17 +1,73 @@
+# frozen_string_literal: true
+
 RSpec.describe SolidusEasypost::ParcelBuilder do
   describe '.from_package', vcr: { cassette_name: 'parcel_builder/from_package' } do
-    it 'builds a parcel with the correct attributes' do
-      parcel = described_class.from_package(create(:shipment).to_package)
+    before { allow(EasyPost::Parcel).to receive(:create).and_call_original }
 
-      expect(parcel).to have_attributes(object: 'Parcel')
+    let(:shipment) { create(:shipment) }
+
+    context 'when there is only the weight set' do
+      it 'builds a parcel with the correct attributes' do
+        parcel = described_class.from_package(shipment.to_package)
+
+        expect(EasyPost::Parcel)
+          .to have_received(:create)
+          .with({ weight: 10.to_f })
+
+        expect(parcel).to have_attributes(object: 'Parcel')
+      end
+    end
+
+    context 'when all the properties are set' do
+      before do
+        shipment.inventory_units.each do |inventory_unit|
+          inventory_unit.variant.update!(height: 2, width: 3, depth: 4)
+        end
+      end
+
+      it 'builds a parcel with the correct attributes' do
+        parcel = described_class.from_package(shipment.to_package)
+
+        expect(EasyPost::Parcel)
+          .to have_received(:create)
+          .with({ height: 2.to_f, length: 4.to_f, weight: 10.to_f, width: 3.to_f })
+
+        expect(parcel).to have_attributes(object: 'Parcel')
+      end
     end
   end
 
   describe '.from_return_authorization', vcr: { cassette_name: 'parcel_builder/from_return_authorization' } do
-    it 'builds a parcel with the correct attributes' do
-      shipment = described_class.from_return_authorization(create(:return_item).return_authorization)
+    before { allow(EasyPost::Parcel).to receive(:create).and_call_original }
 
-      expect(shipment).to have_attributes(object: 'Parcel')
+    let(:return_item) { create(:return_item) }
+
+    context 'when there is only the weight set' do
+      it 'builds a parcel with the correct attributes' do
+        shipment = described_class.from_return_authorization(return_item.return_authorization)
+
+        expect(EasyPost::Parcel)
+          .to have_received(:create)
+          .with({ weight: 0.1e2 })
+
+        expect(shipment).to have_attributes(object: 'Parcel')
+      end
+    end
+
+    context 'when all the properties are set' do
+      before do
+        return_item.inventory_unit.variant.update!(height: 2, width: 3, depth: 4)
+      end
+
+      it 'builds a parcel with the correct attributes' do
+        shipment = described_class.from_return_authorization(return_item.return_authorization)
+
+        expect(EasyPost::Parcel)
+          .to have_received(:create)
+          .with({ height: 0.2e1, length: 0.4e1, weight: 0.1e2, width: 0.3e1 })
+
+        expect(shipment).to have_attributes(object: 'Parcel')
+      end
     end
   end
 end


### PR DESCRIPTION
This is needed to send more information to EasyPost which will return the rates with more accurate prices.

Check the EasyPost gem documentation for more information about the Parcel object: https://github.com/EasyPost/easypost-ruby#example