### PR TITLE
Add custom parcel dimension calculator class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # solidus_easypost
 
-[![CircleCI](https://circleci.com/gh/solidusio-contrib/solidus_easypost.svg?style=shield)](https://circleci.com/gh/solidusio-contrib/solidus_easypost)
-[![codecov](https://codecov.io/gh/solidusio-contrib/solidus_easypost/branch/master/graph/badge.svg)](https://codecov.io/gh/solidusio-contrib/solidus_easypost)
+
 
 This is an extension to integrate EasyPost with Solidus.
 
@@ -44,7 +43,7 @@ for all shipments. The cheapest rate will be selected by default, but your users
 change the selected rate in the `delivery` step of the checkout process, if they wish.
 
 Admins will also be able to download the postage label associated to each EasyPost shipment after
-a shipment has been bought. 
+a shipment has been bought.
 
 ### Buying labels upon shipping
 
@@ -69,6 +68,12 @@ enabled before they are visible and selectable in the storefront during the chec
 
 If you want to override this logic, you can provide your own `shipping_method_selector_class`.
 
+### Customizing parcel dimension calculator
+
+By default, the extension will use the default weight dimension calculator to calculate the parcel dimension that is passed to EasyPost. The default calculator uses the variants weight to calculate the parcel weight without taking into consideration the other package properties like `width`, `height`, and `lenght`.
+
+If you want to override this logic, you can provide your own `parcel_dimension_calculator_class`.
+
 ### Tracking cartons via EasyPost
 
 You can optionally track packages via EasyPost's [Trackers API](https://www.easypost.com/docs/api#trackers).
@@ -86,7 +91,7 @@ retrieve the tracker in the future.
 > in `spree_cartons` contains a valid tracking number, and that the `carrier` column in
 > `spree_shipping_methods` contains a carrier name [that EasyPost will recognize](https://www.easypost.com/docs/api#carrier-tracking-strings).
 > The extension already generates compliant shipping methods by default, but you may need to change
-> the data on your custom shipping methods if you want to track them. 
+> the data on your custom shipping methods if you want to track them.
 
 You can also enable automatic tracking for all created cartons:
 
@@ -108,9 +113,7 @@ extension. When the extension is available, a webhook will be automatically conf
 configuration:
 
 - *Environment:* `Production` or `Test`
-- *Webhook URL:* `https://your-store.com/webhooks/easypost_trackers?token=[YOUR_TOKEN]` (replace
-  `[YOUR_TOKEN]` with the API key of an admin user or, better yet, a 
-  [webhook user](https://github.com/solidusio-contrib/solidus_webhooks#restricting-permissions)
+- *Webhook URL:* `https://your-store.com/webhooks/easypost_trackers?token=[YOUR_TOKEN]` (replace`[YOUR_TOKEN]` with the API key of an admin user or, better yet, a[webhook user](https://github.com/solidusio-contrib/solidus_webhooks#restricting-permissions)
 
 Now, when Solidus gets a tracking update from EasyPost, a `solidus_easypost.tracker.updated` event
 will be fired. The event's payload will contain the `:carton` and `:payload` keys, with the
@@ -155,7 +158,7 @@ $ bin/rails server
 => Rails 6.0.2.1 application starting in development
 * Listening on tcp://127.0.0.1:3000
 Use Ctrl-C to stop
-```  
+```
 
 ### Updating the changelog
 

--- a/app/models/solidus_easypost/parcel_dimension.rb
+++ b/app/models/solidus_easypost/parcel_dimension.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  class ParcelDimension
+    def initialize(**params)
+      raise ArgumentError, 'The weight param is mandatory!' unless valid_value?(value: params[:weight])
+
+      @weight = params[:weight]
+      @width = params[:width]
+      @height = params[:height]
+      @depth = params[:depth]
+    end
+
+    def to_h
+      hash = {
+        weight: weight
+      }
+
+      hash[:width] = width if valid_value?(value: width)
+      hash[:height] = height if valid_value?(value: height)
+      hash[:length] = depth if valid_value?(value: depth)
+
+      hash
+    end
+
+    private
+
+    def valid_value?(value:)
+      value.present? && !value.zero?
+    end
+
+    attr_reader :width, :height, :depth, :weight
+  end
+end

--- a/lib/generators/solidus_easypost/install/templates/initializer.rb
+++ b/lib/generators/solidus_easypost/install/templates/initializer.rb
@@ -17,4 +17,10 @@ SolidusEasypost.configure do |config|
   # `EasyPost::Rate` instance and returning the shipping method for
   # that rate.
   # config.shipping_method_selector_class = 'SolidusEasypost::ShippingMethodSelector'
+
+  # A class that responds to '#compute', accepting a `SolidusEasypost::ReturnAuthorization`
+  # instance or a `Spree::Stock::Package` instance and returing the `SolidusEasypost::ParcelDimension` object.
+  # The `SolidusEasypost::Calculator::BaseDimensionCalculator` class can be extended to have a common
+  # functionality.
+  # config.parcel_dimension_calculator_class = 'SolidusEasypost::Calculator::WeightDimensionCalculator'
 end

--- a/lib/solidus_easypost.rb
+++ b/lib/solidus_easypost.rb
@@ -14,7 +14,10 @@ require 'solidus_easypost/shipment_builder'
 require 'solidus_easypost/estimator'
 require 'solidus_easypost/shipping_rate_calculator'
 require 'solidus_easypost/shipping_method_selector'
+require 'solidus_easypost/calculator/base_dimension_calculator'
+require 'solidus_easypost/calculator/weight_dimension_calculator'
 require 'solidus_easypost/tracker_webhook_handler'
+require 'solidus_easypost/errors/unknown_partial_resource_error'
 
 module SolidusEasypost
   class << self

--- a/lib/solidus_easypost/calculator/base_dimension_calculator.rb
+++ b/lib/solidus_easypost/calculator/base_dimension_calculator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  module Calculator
+    class BaseDimensionCalculator
+      def compute(resource)
+        case resource
+        when ::SolidusEasypost::ReturnAuthorization
+          compute_for_return_authorization(resource)
+        when ::Spree::Stock::Package
+          compute_for_package(resource)
+        else
+          raise SolidusEasypost::Errors::UnknownPartialResourceError
+        end
+      end
+
+      protected
+
+      def compute_for_return_authorization(return_authorization)
+        raise NotImplementedError
+      end
+
+      def compute_for_package(package)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/solidus_easypost/calculator/weight_dimension_calculator.rb
+++ b/lib/solidus_easypost/calculator/weight_dimension_calculator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  module Calculator
+    class WeightDimensionCalculator < BaseDimensionCalculator
+      protected
+
+      def compute_for_return_authorization(return_authorization)
+        total_weight = return_authorization.inventory_units.joins(:variant).sum(:weight)
+        SolidusEasypost::ParcelDimension.new(weight: total_weight)
+      end
+
+      def compute_for_package(package)
+        total_weight = package.contents.sum do |item|
+          item.quantity * item.variant.weight
+        end
+
+        SolidusEasypost::ParcelDimension.new(weight: total_weight)
+      end
+    end
+  end
+end

--- a/lib/solidus_easypost/configuration.rb
+++ b/lib/solidus_easypost/configuration.rb
@@ -3,7 +3,7 @@
 module SolidusEasypost
   class Configuration
     attr_accessor :purchase_labels, :track_all_cartons
-    attr_writer :shipping_rate_calculator_class, :shipping_method_selector_class
+    attr_writer :shipping_rate_calculator_class, :shipping_method_selector_class, :parcel_dimension_calculator_class
 
     def initialize
       self.purchase_labels = true
@@ -18,6 +18,11 @@ module SolidusEasypost
     def shipping_method_selector_class
       @shipping_method_selector_class ||= 'SolidusEasypost::ShippingMethodSelector'
       @shipping_method_selector_class.constantize
+    end
+
+    def parcel_dimension_calculator_class
+      @parcel_dimension_calculator_class ||= 'SolidusEasypost::Calculator::WeightDimensionCalculator'
+      @parcel_dimension_calculator_class.constantize
     end
   end
 end

--- a/lib/solidus_easypost/errors/unknown_partial_resource_error.rb
+++ b/lib/solidus_easypost/errors/unknown_partial_resource_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusEasypost
+  module Errors
+    class UnknownPartialResourceError < StandardError
+      def message
+        'The passed resource must be a Spree::ReturnAuthorization or a Spree::Stock::Package!'
+      end
+    end
+  end
+end

--- a/lib/solidus_easypost/parcel_builder.rb
+++ b/lib/solidus_easypost/parcel_builder.rb
@@ -4,16 +4,23 @@ module SolidusEasypost
   class ParcelBuilder
     class << self
       def from_package(package)
-        total_weight = package.contents.sum do |item|
-          item.quantity * item.variant.weight
-        end
+        parcel_dimension = SolidusEasypost
+                           .configuration
+                           .parcel_dimension_calculator_class
+                           .new
+                           .compute(package)
 
-        ::EasyPost::Parcel.create weight: total_weight
+        ::EasyPost::Parcel.create(parcel_dimension.to_h)
       end
 
       def from_return_authorization(return_authorization)
-        total_weight = return_authorization.inventory_units.joins(:variant).sum(:weight)
-        ::EasyPost::Parcel.create weight: total_weight
+        parcel_dimension = SolidusEasypost
+                           .configuration
+                           .parcel_dimension_calculator_class
+                           .new
+                           .compute(return_authorization)
+
+        ::EasyPost::Parcel.create(parcel_dimension.to_h)
       end
     end
   end

--- a/spec/models/solidus_easypost/parcel_dimension_spec.rb
+++ b/spec/models/solidus_easypost/parcel_dimension_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusEasypost::ParcelDimension do
+  describe '.new' do
+    subject(:instance) { described_class.new(params) }
+
+    let(:params) do
+      { height: 3 }
+    end
+
+    context 'when the weight is not passed' do
+      let(:params) do
+        { height: 3 }
+      end
+
+      it 'raises an argument error exception' do
+        expect {
+          instance
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the passed weight is zero' do
+      let(:params) do
+        { height: 3, weight: 0 }
+      end
+
+      it 'raises an argument error exception' do
+        expect {
+          instance
+        }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#to_h' do
+    subject(:instance_hash) { described_class.new(params).to_h }
+
+    context 'when the params contains zero values' do
+      let(:params) do
+        { weight: 3, width: 0, height: 0, unknown: -1 }
+      end
+
+      it 'returns the correct parcel dimension hash' do
+        expect(instance_hash).to eq({
+          weight: 3
+        })
+      end
+    end
+
+    context 'when the params contains the wrong params' do
+      let(:params) do
+        { weight: 3, unknown: -1, another: 11 }
+      end
+
+      it 'returns the correct parcel dimension hash' do
+        expect(instance_hash).to eq({
+          weight: 3
+        })
+      end
+    end
+
+    context 'when the params contains the correct params' do
+      let(:params) do
+        { weight: 3, width: 1, depth: 6, height: 11 }
+      end
+
+      it 'returns the correct parcel dimension hash' do
+        expect(instance_hash).to eq({
+          height: 11,
+          weight: 3,
+          width: 1,
+          length: 6,
+        })
+      end
+    end
+  end
+end

--- a/spec/solidus_easypost/calculator/weight_dimension_calculator_spec.rb
+++ b/spec/solidus_easypost/calculator/weight_dimension_calculator_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusEasypost::Calculator::WeightDimensionCalculator do
+  describe '#compute' do
+    subject(:compute) { described_class.new.compute(resource) }
+
+    context 'when a wrong resource is passed' do
+      let(:resource) { create(:shipment) }
+
+      it 'raises an unknown partial resource error' do
+        expect { compute }.to raise_error(SolidusEasypost::Errors::UnknownPartialResourceError)
+      end
+    end
+
+    context 'when a Spree::Stock::Package is passed' do
+      let(:resource) { create(:shipment).to_package }
+
+      before { allow(SolidusEasypost::ParcelDimension).to receive(:new) }
+
+      it 'build a parcel dimension' do
+        compute
+
+        expect(SolidusEasypost::ParcelDimension).to have_received(:new).with({ weight: 10.to_f })
+      end
+    end
+
+    context 'when a SolidusEasypost::ReturnAuthorization is passed' do
+      let(:resource) { SolidusEasypost::ReturnAuthorization.new(create(:return_authorization)) }
+
+      before { allow(SolidusEasypost::ParcelDimension).to receive(:new) }
+
+      it 'build a parcel dimension' do
+        compute
+
+        expect(SolidusEasypost::ParcelDimension).to have_received(:new).with({ weight: 0.to_f })
+      end
+    end
+  end
+end

--- a/spec/solidus_easypost/parcel_builder_spec.rb
+++ b/spec/solidus_easypost/parcel_builder_spec.rb
@@ -1,17 +1,113 @@
+# frozen_string_literal: true
+
 RSpec.describe SolidusEasypost::ParcelBuilder do
   describe '.from_package', vcr: { cassette_name: 'parcel_builder/from_package' } do
-    it 'builds a parcel with the correct attributes' do
-      parcel = described_class.from_package(create(:shipment).to_package)
+    let(:shipment) { create(:shipment) }
+    let(:package) { shipment.to_package }
+    let(:parcel_dimension_calculator) { instance_spy('SolidusEasypost.configuration.parcel_dimension_calculator_class') }
+    let(:parcel_dimension) { instance_spy('SolidusEasypost::ParcelDimension') }
 
-      expect(parcel).to have_attributes(object: 'Parcel')
+    before do
+      allow(SolidusEasypost.configuration.parcel_dimension_calculator_class)
+        .to receive(:new)
+        .and_return(parcel_dimension_calculator)
+
+      allow(parcel_dimension_calculator).to receive(:compute).and_return(parcel_dimension)
+      allow(parcel_dimension).to receive(:to_h).and_return(dimension_hash)
+      allow(EasyPost::Parcel).to receive(:create).and_call_original
+    end
+
+    context 'when there is only the weight set' do
+      let(:dimension_hash) { { weight: 10.to_f } }
+
+      it 'builds a parcel with the correct attributes' do
+        parcel = described_class.from_package(package)
+
+        expect(parcel_dimension_calculator)
+          .to have_received(:compute)
+          .with(package)
+
+        expect(EasyPost::Parcel)
+          .to have_received(:create)
+          .with({ weight: 10.to_f })
+
+        expect(parcel).to have_attributes(object: 'Parcel')
+      end
+    end
+
+    context 'when all the properties are set' do
+      let(:dimension_hash) do
+        { weight: 10.to_f, height: 2.to_f, width: 3.to_f, depth: 4.to_f }
+      end
+
+      it 'builds a parcel with the correct attributes' do
+        parcel = described_class.from_package(package)
+
+        expect(parcel_dimension_calculator)
+          .to have_received(:compute)
+          .with(package)
+
+        expect(EasyPost::Parcel)
+          .to have_received(:create)
+          .with({ weight: 10.to_f, height: 2.to_f, width: 3.to_f, depth: 4.to_f })
+
+        expect(parcel).to have_attributes(object: 'Parcel')
+      end
     end
   end
 
   describe '.from_return_authorization', vcr: { cassette_name: 'parcel_builder/from_return_authorization' } do
-    it 'builds a parcel with the correct attributes' do
-      shipment = described_class.from_return_authorization(create(:return_item).return_authorization)
+    let(:return_item) { create(:return_item) }
+    let(:return_authorization) { return_item.return_authorization }
+    let(:parcel_dimension_calculator) { instance_spy('SolidusEasypost.configuration.parcel_dimension_calculator_class') }
+    let(:parcel_dimension) { instance_spy('SolidusEasypost::ParcelDimension') }
 
-      expect(shipment).to have_attributes(object: 'Parcel')
+    before do
+      allow(SolidusEasypost.configuration.parcel_dimension_calculator_class)
+        .to receive(:new)
+        .and_return(parcel_dimension_calculator)
+
+      allow(parcel_dimension_calculator).to receive(:compute).and_return(parcel_dimension)
+      allow(parcel_dimension).to receive(:to_h).and_return(dimension_hash)
+      allow(EasyPost::Parcel).to receive(:create).and_call_original
+    end
+
+    context 'when there is only the weight set' do
+      let(:dimension_hash) { { weight: 10.to_f } }
+
+      it 'builds a parcel with the correct attributes' do
+        parcel = described_class.from_return_authorization(return_authorization)
+
+        expect(parcel_dimension_calculator)
+          .to have_received(:compute)
+          .with(return_authorization)
+
+        expect(EasyPost::Parcel)
+          .to have_received(:create)
+          .with({ weight: 10.to_f })
+
+        expect(parcel).to have_attributes(object: 'Parcel')
+      end
+    end
+
+    context 'when all the properties are set' do
+      let(:dimension_hash) do
+        { weight: 10.to_f, height: 2.to_f, width: 3.to_f, depth: 4.to_f }
+      end
+
+      it 'builds a parcel with the correct attributes' do
+        parcel = described_class.from_return_authorization(return_authorization)
+
+        expect(parcel_dimension_calculator)
+          .to have_received(:compute)
+          .with(return_authorization)
+
+        expect(EasyPost::Parcel)
+          .to have_received(:create)
+          .with({ weight: 10.to_f, height: 2.to_f, width: 3.to_f, depth: 4.to_f })
+
+        expect(parcel).to have_attributes(object: 'Parcel')
+      end
     end
   end
 end

--- a/spec/solidus_easypost/shipment_builder_spec.rb
+++ b/spec/solidus_easypost/shipment_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe SolidusEasypost::ShipmentBuilder do
   describe '.from_package', vcr: { cassette_name: 'shipment_builder/from_package' } do
     it 'builds a shipment with the correct attributes' do
@@ -17,7 +19,8 @@ RSpec.describe SolidusEasypost::ShipmentBuilder do
 
   describe '.from_return_authorization', vcr: { cassette_name: 'shipment_builder/from_return_authorization' } do
     it 'builds a shipment with the correct attributes' do
-      shipment = described_class.from_return_authorization(create(:return_item).return_authorization)
+      solidus_return_authorization = create(:return_item).return_authorization
+      shipment = described_class.from_return_authorization(SolidusEasypost::ReturnAuthorization.new(solidus_return_authorization))
 
       expect(shipment).to have_attributes(object: 'Shipment')
     end


### PR DESCRIPTION
This PR is needed to allow the application to change the parcel dimension calculation based on their needs.
The `SolidusEasypost::WeightDimensionCalculator` is the default calculator that doesn't change the default logic.
The applications that use this extension can define a custom class changing the extension configuration.

These changes were made to adding the ability to improve the `Easypost::Parcel` input enhancing the calculation of the rates with more accurate prices.